### PR TITLE
expand MS2DeepScoreMonteCarlo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - `MS2DeepScoreMonteCarlo` Monte-Carlo dropout based ensembling do obtain mean/median score and STD [#65](https://github.com/matchms/ms2deepscore/pull/65)
+- choice between `median` (default) and `mean` ensemble score which come with `IQR` and `STD` as uncertainty measures [#86](https://github.com/matchms/ms2deepscore/pull/86)
+- `dropout_in_first_layer` option for SiameseModel (default is False) [#86](https://github.com/matchms/ms2deepscore/pull/86)
 - `use_fixed_set` option for data generators to create deterministic training/testing data with fixed random seed [#73](https://github.com/matchms/ms2deepscore/issues/73)
 
 ## Changed

--- a/ms2deepscore/MS2DeepScoreMonteCarlo.py
+++ b/ms2deepscore/MS2DeepScoreMonteCarlo.py
@@ -98,11 +98,8 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
         if np.unique(dropout_rates).shape[0] > 1:
             print(f"Found multiple different dropout rates. Selected 1st dropout rate: {dropout_rates[0]}")
         dropout_rate = dropout_rates[0]
-        
-        if 'dropout' in self.model.base.layers[3].name:
-            dropout_in_first_layer = True
-        else:
-            dropout_in_first_layer = False
+
+        dropout_in_first_layer = ('dropout' in self.model.base.layers[3].name)
 
         # re-build base network with dropout layers always on
         base = self.model.get_base_model(input_dim=self.input_vector_dim,
@@ -174,12 +171,12 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
             average_similarities = median_pooling(ms2ds_similarity, self.n_ensembles)
         elif self.average_type == "mean":
             average_similarities = mean_pooling(ms2ds_similarity, self.n_ensembles)
-        
+
         similarities=np.empty((average_similarities.shape[0],
                               average_similarities.shape[1]), dtype=self.score_datatype)
         similarities['score'] = average_similarities
         similarities['std'] = std_pooling(ms2ds_similarity, self.n_ensembles)
-        return similarities 
+        return similarities
 
     def calculate_vectors(self, spectrum_list: List[Spectrum]) -> Tuple[np.ndarray, np.ndarray]:
         """Returns a list of vectors for all spectra

--- a/ms2deepscore/MS2DeepScoreMonteCarlo.py
+++ b/ms2deepscore/MS2DeepScoreMonteCarlo.py
@@ -65,7 +65,7 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
             Choice between "median" and "mean" defining which type of averaging is used
             to compute the similarity score from all ensemble scores. Default is "median"
             in which case the uncertainty will be evaluate by the interquantile range (IQR).
-            When usind "mean" the standard deviation is taken as uncertainty measure.
+            When using "mean" the standard deviation is taken as uncertainty measure.
         progress_bar:
             Set to True to monitor the embedding creating with a progress bar.
             Default is False.

--- a/ms2deepscore/MS2DeepScoreMonteCarlo.py
+++ b/ms2deepscore/MS2DeepScoreMonteCarlo.py
@@ -5,7 +5,8 @@ from matchms.similarity.BaseSimilarity import BaseSimilarity
 from tqdm import tqdm
 
 from .vector_operations import cosine_similarity_matrix
-from .vector_operations import mean_pooling, median_pooling, std_pooling
+from .vector_operations import mean_pooling, median_pooling
+from .vector_operations import std_pooling, iqr_pooling
 from .typing import BinnedSpectrumType
 
 
@@ -35,7 +36,7 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
         # Load pretrained model
         model = load_model("model_file_123.hdf5")
 
-        similarity_measure = MS2DeepScoreMonteCarlo(model, n_ensembles=5)
+        similarity_measure = MS2DeepScoreMonteCarlo(model, n_ensembles=10)
         # Calculate scores and get matchms.Scores object
         scores = calculate_scores(references, queries, similarity_measure)
 
@@ -44,7 +45,7 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g. ("score", "float") or [("score", "float"), ("matches", "int")]
-    score_datatype = [("score", np.float64), ("std", np.float64)]
+    score_datatype = [("score", np.float64), ("uncertainty", np.float64)]
 
     def __init__(self, model, n_ensembles: int = 10, average_type: str = "median",
                  progress_bar: bool = True):
@@ -61,8 +62,10 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
             n_ensembles will lead to n_ensembles^2 scores of which the mean and STD will
             be taken.
         average_type:
-            Choice between "median" and "mean" defineing which type of averaging is used
-            to compute the similarity score from all ensemble scores. Default is "median".
+            Choice between "median" and "mean" defining which type of averaging is used
+            to compute the similarity score from all ensemble scores. Default is "median"
+            in which case the uncertainty will be evaluate by the interquantile range (IQR).
+            When usind "mean" the standard deviation is taken as uncertainty measure.
         progress_bar:
             Set to True to monitor the embedding creating with a progress bar.
             Default is False.
@@ -124,8 +127,8 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
 
         Returns
         -------
-        ms2ds_ensemble_similarity, ms2ds_ensemble_std
-            Tuple of MS2DeepScore similarity score and uncertainty measure (STD).
+        ms2ds_ensemble_similarity, ms2ds_ensemble_uncertainty
+            Tuple of MS2DeepScore similarity score and uncertainty measure (STD/IQR).
         """
         binned_reference = self.model.spectrum_binner.transform([reference])[0]
         binned_query = self.model.spectrum_binner.transform([query])[0]
@@ -134,9 +137,11 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
         scores_ensemble = cosine_similarity_matrix(reference_vectors, query_vectors)
         if self.average_type == "median":
             average_similarity = np.median(scores_ensemble)
+            uncertainty = iqr_pooling(scores_ensemble, self.n_ensembles)[0, 0]
         elif self.average_type == "mean":
             average_similarity = np.mean(scores_ensemble)
-        return np.asarray((average_similarity, scores_ensemble.std()),
+            uncertainty = scores_ensemble.std()
+        return np.asarray((average_similarity, uncertainty),
                           dtype=self.score_datatype)
 
     def matrix(self, references: List[Spectrum], queries: List[Spectrum],
@@ -155,8 +160,8 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
 
         Returns
         -------
-        ms2ds_ensemble_similarity, ms2ds_ensemble_std
-            Array of Tuples of MS2DeepScore similarity score and uncertainty measure (STD).
+        ms2ds_ensemble_similarity, ms2ds_ensemble_uncertainties
+            Array of Tuples of MS2DeepScore similarity score and uncertainty measure (STD/IQR).
         """
         reference_vectors = self.calculate_vectors(references)
         if is_symmetric:
@@ -169,13 +174,15 @@ class MS2DeepScoreMonteCarlo(BaseSimilarity):
         ms2ds_similarity = cosine_similarity_matrix(reference_vectors, query_vectors)
         if self.average_type == "median":
             average_similarities = median_pooling(ms2ds_similarity, self.n_ensembles)
+            uncertainties = iqr_pooling(ms2ds_similarity, self.n_ensembles)
         elif self.average_type == "mean":
             average_similarities = mean_pooling(ms2ds_similarity, self.n_ensembles)
+            uncertainties = std_pooling(ms2ds_similarity, self.n_ensembles)
 
         similarities=np.empty((average_similarities.shape[0],
                               average_similarities.shape[1]), dtype=self.score_datatype)
         similarities['score'] = average_similarities
-        similarities['std'] = std_pooling(ms2ds_similarity, self.n_ensembles)
+        similarities['uncertainty'] = uncertainties
         return similarities
 
     def calculate_vectors(self, spectrum_list: List[Spectrum]) -> Tuple[np.ndarray, np.ndarray]:

--- a/ms2deepscore/vector_operations.py
+++ b/ms2deepscore/vector_operations.py
@@ -116,7 +116,7 @@ def median_pooling(scores_ensemble: np.ndarray, n_ensembles: int) -> np.ndarray:
 
 @numba.njit(fastmath=True)
 def std_pooling(scores_ensemble: np.ndarray, n_ensembles: int) -> np.ndarray:
-    """Do standard deviation pooling on an ensemble of score std's."""
+    """Do standard deviation pooling on an ensemble of scores."""
     dim_0 = int(scores_ensemble.shape[0]/n_ensembles)
     dim_1 = int(scores_ensemble.shape[1]/n_ensembles)
     scores_pooled = np.zeros((dim_0, dim_1))
@@ -125,4 +125,20 @@ def std_pooling(scores_ensemble: np.ndarray, n_ensembles: int) -> np.ndarray:
         for j in range(dim_1):
             scores_pooled[i, j] = np.std(scores_ensemble[i*n_ensembles:(i+1)*n_ensembles,
                                                          j*n_ensembles:(j+1)*n_ensembles])
+    return scores_pooled
+
+
+@numba.njit(fastmath=True)
+def iqr_pooling(scores_ensemble: np.ndarray, n_ensembles: int) -> np.ndarray:
+    """Do interquartile range (IQR) pooling on an ensemble of scores."""
+    dim_0 = int(scores_ensemble.shape[0]/n_ensembles)
+    dim_1 = int(scores_ensemble.shape[1]/n_ensembles)
+    scores_pooled = np.zeros((dim_0, dim_1))
+
+    for i in range(dim_0):
+        for j in range(dim_1):
+            q75, q25 = np.percentile(scores_ensemble[i*n_ensembles:(i+1)*n_ensembles,
+                                                     j*n_ensembles:(j+1)*n_ensembles],
+                                     [75 ,25])
+            scores_pooled[i, j] = q75 - q25
     return scores_pooled

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -71,6 +71,18 @@ def test_siamese_model_different_architecture():
     assert model.base.output_shape == (None, 100), "Expected different output shape of base model"
 
 
+def test_siamese_model_dropout_in_first_layer():
+    spectrum_binner, test_generator = get_test_binner_and_generator()
+    model = SiameseModel(spectrum_binner, base_dims=(200, 200, 100, 100, 100),
+                         embedding_dim=100, dropout_rate=0.2, dropout_in_first_layer=True)
+    model.compile(loss='mse', optimizer=keras.optimizers.Adam(lr=0.001))
+    assert len(model.model.layers) == 4, "Expected different number of layers"
+    assert len(model.model.layers[2].layers) == len(model.base.layers) == 17, \
+        "Expected different number of layers"
+    assert model.model.input_shape == [(None, 339), (None, 339)], "Expected different input shape"
+    assert model.base.output_shape == (None, 100), "Expected different output shape of base model"
+
+
 def test_siamese_model_different_regularization_rates():
     spectrum_binner, test_generator = get_test_binner_and_generator()
     model = SiameseModel(spectrum_binner, base_dims=(200,),

--- a/tests/test_ms2deepscoremontecarlo.py
+++ b/tests/test_ms2deepscoremontecarlo.py
@@ -41,8 +41,8 @@ def test_MS2DeepScoreMonteCarlo_score_pair():
     score = similarity_measure.pair(spectrums[0], spectrums[1])
     assert score['score'].dtype == np.float64, "Expected float as score."
     assert score['score'] > 0.65 and score['score'] < 0.9, "Expected score in different range"
-    assert score['std'].dtype == np.float64, "Expected float as STD."
-    assert score['std'] > 0.01 and score['std'] < 0.06, "Expected STD(score) in different range"
+    assert score['uncertainty'].dtype == np.float64, "Expected float as STD."
+    assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.06, "Expected STD(score) in different range"
 
 
 def test_MS2DeepScoreMonteCarlo_score_matrix():
@@ -50,8 +50,8 @@ def test_MS2DeepScoreMonteCarlo_score_matrix():
     spectrums, _, similarity_measure = get_test_ms2_deep_score_instance(n_ensembles=5)
     scores = similarity_measure.matrix(spectrums[:4], spectrums[:3])
     assert scores['score'].shape == (4, 3), "Expected different shape"
-    assert scores['std'].shape == (4, 3), "Expected different shape"
-    assert np.max(scores['std']) < 0.1, "Expected lower STD"
+    assert scores['uncertainty'].shape == (4, 3), "Expected different shape"
+    assert np.max(scores['uncertainty']) < 0.1, "Expected lower STD"
     assert np.max(scores['score']) > 0.5, "Expected higher scores"
 
 

--- a/tests/test_ms2deepscoremontecarlo.py
+++ b/tests/test_ms2deepscoremontecarlo.py
@@ -45,7 +45,7 @@ def test_MS2DeepScoreMonteCarlo_score_pair(average_type):
     assert score['score'].dtype == np.float64, "Expected float as score."
     assert score['score'] > 0.65 and score['score'] < 0.9, "Expected score in different range"
     assert score['uncertainty'].dtype == np.float64, "Expected float as uncertainty."
-    assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.06, "Expected STD(score) in different range"
+    assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.08, "Expected uncertainty in different range"
 
 
 @pytest.mark.parametrize("average_type", ['median', 'mean'])
@@ -56,7 +56,7 @@ def test_MS2DeepScoreMonteCarlo_score_matrix(average_type):
     scores = similarity_measure.matrix(spectrums[:4], spectrums[:3])
     assert scores['score'].shape == (4, 3), "Expected different shape"
     assert scores['uncertainty'].shape == (4, 3), "Expected different shape"
-    assert np.max(scores['uncertainty']) < 0.1, "Expected lower uncertainty"
+    assert np.max(scores['uncertainty']) < 0.2, "Expected lower uncertainty"
     assert np.max(scores['score']) > 0.5, "Expected higher scores"
 
 

--- a/tests/test_ms2deepscoremontecarlo.py
+++ b/tests/test_ms2deepscoremontecarlo.py
@@ -38,21 +38,21 @@ def test_MS2DeepScoreMonteCarlo_vector_creation():
 def test_MS2DeepScoreMonteCarlo_score_pair():
     """Test score calculation using *.pair* method."""
     spectrums, _, similarity_measure = get_test_ms2_deep_score_instance(n_ensembles=5)
-    score, score_std = similarity_measure.pair(spectrums[0], spectrums[1])
-    assert isinstance(score, np.float64), "Expected float as score."
-    assert score > 0.65 and score < 0.9, "Expected score in different range"
-    assert isinstance(score_std, np.float64), "Expected float as STD."
-    assert score_std > 0.01 and score_std < 0.06, "Expected STD(score) in different range"
+    score = similarity_measure.pair(spectrums[0], spectrums[1])
+    assert score['score'].dtype == np.float64, "Expected float as score."
+    assert score['score'] > 0.65 and score['score'] < 0.9, "Expected score in different range"
+    assert score['std'].dtype == np.float64, "Expected float as STD."
+    assert score['std'] > 0.01 and score['std'] < 0.06, "Expected STD(score) in different range"
 
 
 def test_MS2DeepScoreMonteCarlo_score_matrix():
     """Test score calculation using *.matrix* method."""
     spectrums, _, similarity_measure = get_test_ms2_deep_score_instance(n_ensembles=5)
-    scores, scores_std = similarity_measure.matrix(spectrums[:4], spectrums[:3])
-    assert scores.shape == (4, 3), "Expected different shape"
-    assert scores_std.shape == (4, 3), "Expected different shape"
-    assert np.max(scores_std) < 0.1, "Expected lower STD"
-    assert np.max(scores) > 0.5, "Expected higher scores"
+    scores = similarity_measure.matrix(spectrums[:4], spectrums[:3])
+    assert scores['score'].shape == (4, 3), "Expected different shape"
+    assert scores['std'].shape == (4, 3), "Expected different shape"
+    assert np.max(scores['std']) < 0.1, "Expected lower STD"
+    assert np.max(scores['score']) > 0.5, "Expected higher scores"
 
 
 def test_MS2DeepScoreMonteCarlo_score_matrix_symmetric_wrong_use():

--- a/tests/test_ms2deepscoremontecarlo.py
+++ b/tests/test_ms2deepscoremontecarlo.py
@@ -9,7 +9,7 @@ from tests.test_user_worfklow import load_processed_spectrums
 TEST_RESOURCES_PATH = Path(__file__).parent / 'resources'
 
 
-def get_test_ms2_deep_score_instance(n_ensembles, average_type):
+def get_test_ms2_deep_score_instance(n_ensembles, average_type="median"):
     """Load data and models for MS2DeepScore unit tests."""
     spectrums = load_processed_spectrums()
 
@@ -18,7 +18,7 @@ def get_test_ms2_deep_score_instance(n_ensembles, average_type):
     model = load_model(model_file)
 
     similarity_measure = MS2DeepScoreMonteCarlo(model, n_ensembles,
-                                                average_type="median")
+                                                average_type)
     return spectrums, model, similarity_measure
 
 
@@ -45,7 +45,12 @@ def test_MS2DeepScoreMonteCarlo_score_pair(average_type):
     assert score['score'].dtype == np.float64, "Expected float as score."
     assert score['score'] > 0.65 and score['score'] < 0.9, "Expected score in different range"
     assert score['uncertainty'].dtype == np.float64, "Expected float as uncertainty."
-    assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.08, "Expected uncertainty in different range"
+    if average_type == 'median':
+        assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.12, \
+            "Expected uncertainty in different range"
+    else:
+        assert score['uncertainty'] > 0.01 and score['uncertainty'] < 0.06, \
+            "Expected uncertainty in different range"
 
 
 @pytest.mark.parametrize("average_type", ['median', 'mean'])

--- a/tests/test_vector_operations.py
+++ b/tests/test_vector_operations.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 from ms2deepscore.vector_operations import cosine_similarity, cosine_similarity_matrix
-from ms2deepscore.vector_operations import mean_pooling, median_pooling, std_pooling
+from ms2deepscore.vector_operations import mean_pooling, median_pooling
+from ms2deepscore.vector_operations import iqr_pooling, std_pooling
 
 
 @pytest.mark.parametrize("numba_compiled", [True, False])
@@ -152,3 +153,21 @@ def test_std_pooling(numba_compiled):
     std_expected = np.std([0,1,4,5]) * np.ones((2, 2))
     assert np.allclose(scores_std, std_expected, atol=1e-8), \
         "Expected different pooled standard deviations"
+
+
+@pytest.mark.parametrize("numba_compiled", [True, False])
+def test_iqr_pooling(numba_compiled):
+    """Test if scores are pooled correctly."""
+    scores = np.arange(0, 16).reshape(4, 4)
+    scores[0,0] = 10
+    scores[2,2] = 0
+
+    if numba_compiled:
+        scores_iqr = iqr_pooling(scores, 2)
+    else:
+        scores_iqr = iqr_pooling.py_func(scores, 2)
+
+    iqr_expected = np.array([[3. , 3.5],
+                             [3.5, 6. ]])
+    assert np.allclose(scores_iqr, iqr_expected, atol=1e-8), \
+        "Expected different pooled interquantile ranges"


### PR DESCRIPTION
- make scores a structured numpy array (so it can be accessed by `scores["score"]` and `scores["uncertainty"]`)
- add option to have dropout in first network layer (default is False)
- allow to chose between mean (with uncertainty measured by STD) and median (uncertainty measured by IQR).