### PR TITLE
Speed-up spectrum binning

### DIFF
--- a/ms2deepscore/spectrum_binning_fixed.py
+++ b/ms2deepscore/spectrum_binning_fixed.py
@@ -39,7 +39,7 @@ def create_peak_list_fixed(spectrums, peaks_vocab, d_bins,
         
         # Find binned peaks present in peaks_vocab
         idx_in_vocab = [i for i, x in enumerate(doc) if x in peaks_vocab.keys()]
-        idx_not_in_vocab = list(set(np.arange(len(doc))) - set(idx_in_vocab))
+        idx_not_in_vocab = [i for i in np.arange(len(doc)) if i not in idx_in_vocab]
     
         doc_bow = [peaks_vocab[doc[i]] for i in idx_in_vocab]
 

--- a/ms2deepscore/spectrum_binning_fixed.py
+++ b/ms2deepscore/spectrum_binning_fixed.py
@@ -39,7 +39,7 @@ def create_peak_list_fixed(spectrums, peaks_vocab, d_bins,
         
         # Find binned peaks present in peaks_vocab
         idx_in_vocab = [i for i, x in enumerate(doc) if x in peaks_vocab.keys()]
-        idx_not_in_vocab = [i for i in np.arange(len(doc)) if i not in idx_in_vocab]
+        idx_not_in_vocab = list(set(np.arange(len(doc))) - set(idx_in_vocab))
     
         doc_bow = [peaks_vocab[doc[i]] for i in idx_in_vocab]
 


### PR DESCRIPTION
This PR address the following issue #46 

There is one line of code in the `create_peak_list_fixed`  whose performance is O(N²). With N being the total number of peaks within a spectrum. So imagine cases where the spectrum can contain ~70k peaks. In these cases, the algorithm would go over the peaks 4 billion times (70k²).

Check the below snippet:
```
> ms2deepscore.spectrum_binning_fixed.py: create_peak_list_fixed:L42

idx_not_in_vocab = [i for i in np.arange(len(doc)) if i not in idx_in_vocab]

```

The length of `doc` and `idx_in_vocab` is the total number of peaks. For each item of `doc`, it checks that is not present in the `idx_in_vocab`. And here is where the problem lies because for container types such as `list`, `tuple`, `set`, `frozenset`, `dict`, or `collections.deque`, the expression `x in y` or `x not in y` is equivalent to `any(x is e or x == e for e in y)`.  As we can see, there is a hidden for loop which slows down the computation.

The solution I proposed is to use sets instead.

Set is faster due to near-instant 'contains' checks for membership. It finds the element by computing a hash from the key.
```
idx_not_in_vocab = list(set(np.arange(len(doc))) - set(idx_in_vocab))
````

And this solution is safe because `idx_in_vocab` is derived from `peaks_vocab` which is a set, thus we don't lose any data by transforming them into sets. 