### PR TITLE
Update SiameseModel to tensorflow 2.6

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Show pip list
         run: |
           pip list
-      - name: Run test with coverage
+      - name: Run test with tensorflow version 2.4
         run: pytest
       - name: Install Tensorflow version 2.5
         run: |
@@ -101,5 +101,5 @@ jobs:
       - name: Show pip list
         run: |
           pip list
-      - name: Run test with coverage
+      - name: Run test with tensorflow version 2.5
         run: pytest

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -83,13 +83,21 @@ jobs:
         run: |
           which python
           python --version
-      - name: Install dependencies
+      - name: Install Tensorflow version 2.4
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
-      - name: Install specific Tensorflow version
+          pip install "tensorflow>=2.4,<2.5"
+      - name: Install other dependencies
         run: |
-          pip install --upgrade "tensorflow<2.6"
+          pip install -e .[dev]
+      - name: Show pip list
+        run: |
+          pip list
+      - name: Run test with coverage
+        run: pytest
+      - name: Install Tensorflow version 2.5
+        run: |
+          pip install --upgrade "tensorflow>=2.5,<2.6"
       - name: Show pip list
         run: |
           pip list

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -89,7 +89,7 @@ jobs:
           pip install -e .[dev]
       - name: Install specific Tensorflow version
         run: |
-          pip install --upgrade tensorflow<2.6
+          pip install --upgrade "tensorflow<2.6"
       - name: Show pip list
         run: |
           pip list

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -69,3 +69,29 @@ jobs:
       - name: Run tests
         run: |
           pytest
+
+  tensorflow_check:
+    name: Tensorflow version check / python-3.8 / ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Python info
+        run: |
+          which python
+          python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Install specific Tensorflow version
+        run: |
+          pip install --upgrade tensorflow<2.6
+      - name: Show pip list
+        run: |
+          pip list
+      - name: Run test with coverage
+        run: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- now compatible with new Tensorflow 2.6, also checked by additional CI runs for Tensorflow 2.4, 2.5 and 2.6 [#92](https://github.com/matchms/ms2deepscore/pull/92)
+
 ## [0.2.1] - 2021-07-20
 
 ## Changed

--- a/ms2deepscore/models/SiameseModel.py
+++ b/ms2deepscore/models/SiameseModel.py
@@ -184,7 +184,7 @@ class SiameseModel:
             assert len(given_model.layers) > 2, "Expected more layers"
             assert len(keras_model.layers[2]) > 1, "Expected more layers for base model"
             
-        valid_keras_model(given_model)
+        valid_keras_model(keras_model)
         self.base = keras_model.layers[2]
         self.model = keras_model
 

--- a/ms2deepscore/models/SiameseModel.py
+++ b/ms2deepscore/models/SiameseModel.py
@@ -182,7 +182,7 @@ class SiameseModel:
         def valid_keras_model(given_model):
             # assert isinstance(given_model, keras.Model), "Expected keras model as input."
             assert len(given_model.layers) > 2, "Expected more layers"
-            assert len(keras_model.layers[2]) > 1, "Expected more layers for base model"
+            assert len(keras_model.layers[2].layers) > 1, "Expected more layers for base model"
             
         valid_keras_model(keras_model)
         self.base = keras_model.layers[2]

--- a/ms2deepscore/models/SiameseModel.py
+++ b/ms2deepscore/models/SiameseModel.py
@@ -180,7 +180,7 @@ class SiameseModel:
 
     def _construct_from_keras_model(self, keras_model):
         def valid_keras_model(given_model):
-            assert isinstance(given_model, keras.Model), "Expected keras model as input."
+            # assert isinstance(given_model, keras.Model), "Expected keras model as input."
             assert len(given_model.layers) > 2, "Expected more layers"
             assert len(keras_model.layers[2]) > 1, "Expected more layers for base model"
             

--- a/ms2deepscore/models/SiameseModel.py
+++ b/ms2deepscore/models/SiameseModel.py
@@ -179,7 +179,12 @@ class SiameseModel:
                            name='head')
 
     def _construct_from_keras_model(self, keras_model):
-        assert isinstance(keras_model, keras.Model), "Expected keras model as input."
+        def valid_keras_model(given_model):
+            assert isinstance(given_model, keras.Model), "Expected keras model as input."
+            assert len(given_model.layers) > 2, "Expected more layers"
+            assert len(keras_model.layers[2]) > 1, "Expected more layers for base model"
+            
+        valid_keras_model(given_model)
         self.base = keras_model.layers[2]
         self.model = keras_model
 

--- a/ms2deepscore/models/SiameseModel.py
+++ b/ms2deepscore/models/SiameseModel.py
@@ -180,7 +180,7 @@ class SiameseModel:
 
     def _construct_from_keras_model(self, keras_model):
         def valid_keras_model(given_model):
-            # assert isinstance(given_model, keras.Model), "Expected keras model as input."
+            assert given_model.layers, "Expected valid keras model as input."
             assert len(given_model.layers) > 2, "Expected more layers"
             assert len(keras_model.layers[2].layers) > 1, "Expected more layers for base model"
             

--- a/ms2deepscore/models/load_model.py
+++ b/ms2deepscore/models/load_model.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Union
 import h5py
-from tensorflow.python.keras.saving import hdf5_format
+from tensorflow import keras
 
 from ms2deepscore.SpectrumBinner import SpectrumBinner
 from .SiameseModel import SiameseModel
@@ -26,7 +26,7 @@ def load_model(filename: Union[str, Path]) -> SiameseModel:
     """
     with h5py.File(filename, mode='r') as f:
         binner_json = f.attrs['spectrum_binner']
-        keras_model = hdf5_format.load_model_from_hdf5(f)
+        keras_model = keras.models.load_model(f)
 
     spectrum_binner = SpectrumBinner.from_json(binner_json)
     return SiameseModel(spectrum_binner, keras_model=keras_model)


### PR DESCRIPTION
Some of our code breaks with the most recent version of Tensorflow (see issue #91).

- I had to change the assertion that looks for a valid keras model. 
(we could maybe add another assert such as `assert model.layers, "Expected valid keras model as input"` ?)
- To be sure it doesn't now break for former tensorflow version I added CI tests for Tensorflow `>=2.4,<2.5` and `>=2.5, <2.6`.
- Tensorflow recommends to not use `tensorflow.python.keras` imports anymore, so I replaced that as well.