### PR TITLE
Change cherry picking algorithm

### DIFF
--- a/ms2deepscore/data_generators.py
+++ b/ms2deepscore/data_generators.py
@@ -5,8 +5,8 @@ from typing import Iterator, List, NamedTuple, Optional
 import numpy as np
 import pandas as pd
 from tensorflow.keras.utils import Sequence  # pylint: disable=import-error
-from ms2deepscore.SpectrumBinner import SpectrumBinner
 from ms2deepscore.spectrum_pair_selection import SelectedCompoundPairs
+from ms2deepscore.SpectrumBinner import SpectrumBinner
 from .typing import BinnedSpectrumType
 
 

--- a/ms2deepscore/spectrum_pair_selection.py
+++ b/ms2deepscore/spectrum_pair_selection.py
@@ -253,23 +253,36 @@ def try_cut_off(nr_of_pairs_in_bin_per_spectrum: List[int],
 
 
 def find_correct_max_nr_of_pairs(nr_of_pairs_in_bin_per_spectrum: List[int], expected_average_nr_of_pairs: int):
-    """Finds the max_nr_of_pairs that should be used to get the expected_average_nr_of_pairs"""
-    correct_max_nr_of_pairs = False
+    """
+    Find the maximum number of pairs that should be used to achieve the expected average number of pairs.
+    
+    Parameters
+    ----------
+    nr_of_pairs_in_bin_per_spectrum: List[int]
+        A list containing the number of pairs found for each InChIKey (for a single bin).
+    expected_average_nr_of_pairs: int
+        The average number of pairs that are expected to be found.
+    """
+    max_pairs_for_expected_avg = None
     average_nr_of_pairs = 0
+
     # Try cut_offs until the nr_of_pairs found is higher than expected_average_nr_of_pairs
-    for cut_off in range(expected_average_nr_of_pairs, max(nr_of_pairs_in_bin_per_spectrum)+1):
+    for cut_off in range(expected_average_nr_of_pairs, max(nr_of_pairs_in_bin_per_spectrum) + 1):
         average_nr_of_pairs = try_cut_off(nr_of_pairs_in_bin_per_spectrum, cut_off)
         if average_nr_of_pairs >= expected_average_nr_of_pairs:
             correct_max_nr_of_pairs = cut_off
             break
-    assert correct_max_nr_of_pairs, "Not enough pairs were found for one of the bins, try increasing the max_oversampling_rate"
-    expected_nr_of_pairs = expected_average_nr_of_pairs*len(nr_of_pairs_in_bin_per_spectrum)
-    found_nr_of_pairs = average_nr_of_pairs*len(nr_of_pairs_in_bin_per_spectrum)
-    # to get the exact average_nr_of_pairs expected, the cut_off will need to be 1 lower for part of the inchikeys.
-    # todo find better name for difference
-    difference = found_nr_of_pairs - expected_nr_of_pairs
-    assert 0 <= difference < len(nr_of_pairs_in_bin_per_spectrum)
-    return difference, correct_max_nr_of_pairs
+
+    assert max_pairs_for_expected_avg, ("Not enough pairs were found for one of the bins,"
+                                        " consider increasing the max_oversampling_rate")
+
+    total_expected_pairs = expected_average_nr_of_pairs * len(nr_of_pairs_in_bin_per_spectrum)
+    total_found_pairs = average_nr_of_pairs * len(nr_of_pairs_in_bin_per_spectrum)
+
+    pair_difference = total_found_pairs - total_expected_pairs
+    assert 0 <= pair_difference < len(nr_of_pairs_per_spectrum)
+
+    return pair_difference, max_pairs_for_expected_avg
 
 
 def select_inchi_for_unique_inchikeys(

--- a/ms2deepscore/spectrum_pair_selection.py
+++ b/ms2deepscore/spectrum_pair_selection.py
@@ -270,7 +270,7 @@ def find_correct_max_nr_of_pairs(nr_of_pairs_in_bin_per_spectrum: List[int], exp
     for cut_off in range(expected_average_nr_of_pairs, max(nr_of_pairs_in_bin_per_spectrum) + 1):
         average_nr_of_pairs = try_cut_off(nr_of_pairs_in_bin_per_spectrum, cut_off)
         if average_nr_of_pairs >= expected_average_nr_of_pairs:
-            correct_max_nr_of_pairs = cut_off
+            max_pairs_for_expected_avg = cut_off
             break
 
     assert max_pairs_for_expected_avg, ("Not enough pairs were found for one of the bins,"
@@ -280,7 +280,7 @@ def find_correct_max_nr_of_pairs(nr_of_pairs_in_bin_per_spectrum: List[int], exp
     total_found_pairs = average_nr_of_pairs * len(nr_of_pairs_in_bin_per_spectrum)
 
     pair_difference = total_found_pairs - total_expected_pairs
-    assert 0 <= pair_difference < len(nr_of_pairs_per_spectrum)
+    assert 0 <= pair_difference < len(nr_of_pairs_in_bin_per_spectrum)
 
     return pair_difference, max_pairs_for_expected_avg
 

--- a/ms2deepscore/spectrum_pair_selection.py
+++ b/ms2deepscore/spectrum_pair_selection.py
@@ -1,5 +1,5 @@
-from typing import List, Tuple
 from collections import Counter
+from typing import List, Tuple
 import numba
 import numpy as np
 from matchms import Spectrum

--- a/ms2deepscore/spectrum_pair_selection.py
+++ b/ms2deepscore/spectrum_pair_selection.py
@@ -223,10 +223,11 @@ def compute_jaccard_similarity_per_bin(
 
 
 def fix_bias(fingerprints: np.ndarray,
-    selection_bins: np.ndarray = np.array([(x/10, x/10 + 0.1) for x in range(0, 10)]),
-    max_pairs_per_bin: int = 20,
-    include_diagonal: bool = True,
-    fix_global_bias: bool = True):
+             selection_bins: np.ndarray = np.array([(x/10, x/10 + 0.1) for x in range(0, 10)]),
+             max_pairs_per_bin: int = 20,
+             max_oversampling_rate = 2,
+             include_diagonal: bool = True,
+             fix_global_bias: bool = True):
     """Returns matrix of jaccard indices between all-vs-all vectors of references
     and queries.
 
@@ -254,8 +255,7 @@ def fix_bias(fingerprints: np.ndarray,
         Sparse array (List of lists) with cherrypicked scores.
     """
     if fix_global_bias:
-        # todo make the nr of times the max pair is used a variable, with as option "inf" meaning it will store everything it finds for each bin. (for anyone without memory constraints and difficult bins)
-        max_pairs_per_bin = max_pairs_per_bin*2
+        max_pairs_per_bin = max_pairs_per_bin*max_oversampling_rate
     selected_pairs_per_bin = compute_jaccard_similarity_per_bin(
         fingerprints,
         selection_bins,
@@ -294,7 +294,7 @@ def try_cut_off(nr_of_pairs_in_bin_per_spectrum, cut_off):
 
 def find_correct_cut_off(nr_of_pairs_in_bin_per_spectrum: List[int], expected_average_nr_of_pairs: int):
     found_cut_off = False
-    for cut_off in range(expected_average_nr_of_pairs, expected_average_nr_of_pairs*2):
+    for cut_off in range(expected_average_nr_of_pairs, max(nr_of_pairs_in_bin_per_spectrum)):
         average_nr_of_pairs = try_cut_off(nr_of_pairs_in_bin_per_spectrum, cut_off)
         if average_nr_of_pairs >= expected_average_nr_of_pairs:
             found_cut_off = cut_off

--- a/ms2deepscore/spectrum_pair_selection.py
+++ b/ms2deepscore/spectrum_pair_selection.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from typing import List, Tuple
-import numba
 import numpy as np
 from matchms import Spectrum
 from matchms.filtering import add_fingerprint
@@ -101,8 +100,8 @@ def compute_fingerprints(spectrums,
         print(f"Successfully generated fingerprints for {len(idx)} of {len(fingerprints)} spectra")
     fingerprints = np.array([fingerprints[i] for i in idx])
     inchikeys14_unique = [inchikeys14_unique[i] for i in idx]
-    spectra_selected = [spectra_selected[i] for i in idx]
-    return fingerprints, inchikeys14_unique, spectra_selected
+    # spectra_selected = [spectra_selected[i] for i in idx]
+    return fingerprints, inchikeys14_unique #, spectra_selected
 
 
 def select_spectrum_pairs_wrapper(
@@ -123,9 +122,9 @@ def select_spectrum_pairs_wrapper(
         Sparse array (List of lists) with cherrypicked scores.
     """
     # pylint: disable=too-many-arguments
-    fingerprints, inchikeys14_unique, spectra_selected = compute_fingerprints(spectrums,
-                                                                              fingerprint_type,
-                                                                              nbits)
+    fingerprints, inchikeys14_unique = compute_fingerprints(spectrums,
+                                                            fingerprint_type,
+                                                            nbits)
     if random_seed is not None:
         np.random.seed(random_seed)
 
@@ -148,7 +147,7 @@ def convert_selected_pairs_per_bin_to_coo_array(selected_pairs_per_bin: List[Lis
     data = []
     inchikey_indexes_i = []
     inchikey_indexes_j = []
-    for bin_idx, scores_per_inchikey in enumerate(selected_pairs_per_bin):
+    for scores_per_inchikey in selected_pairs_per_bin:
         assert len(scores_per_inchikey) == size
         for inchikey_idx_i, scores_list in enumerate(scores_per_inchikey):
             for scores in scores_list:
@@ -182,7 +181,6 @@ def compute_jaccard_similarity_per_bin(
         A list were the indexes are the bin numbers. This contains Lists were the index is the spectrum_i index.
         This list contains a Tuple, with first the spectrum_j index and second the score.
     """
-    # pylint: disable=too-many-locals
     size = fingerprints.shape[0]
     # initialize storing scores
     selected_pairs_per_bin = [[] for _ in range(len(selection_bins))]

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -12,7 +12,7 @@ from ms2deepscore.data_generators import (DataGeneratorAllInchikeys,
 from ms2deepscore.MetadataFeatureGenerator import (CategoricalToBinary,
                                                    StandardScaler)
 from ms2deepscore.spectrum_pair_selection import (SelectedCompoundPairs,
-                                                  compute_spectrum_pairs)
+                                                  select_spectrum_pairs_wrapper)
 from tests.test_user_worfklow import (get_reference_scores,
                                       load_processed_spectrums)
 
@@ -114,12 +114,11 @@ def test_DataGeneratorCherrypicked():
     binned_spectrums = ms2ds_binner.fit_transform(spectrums)
     dimension = len(ms2ds_binner.known_bins)
 
-    scores_selected, inchikeys14 = compute_spectrum_pairs(
+    scp = select_spectrum_pairs_wrapper(
         spectrums,
         selection_bins=np.array([(x/4, x/4 + 0.25) for x in range(0, 4)]),
-        max_pairs_per_bin=1)
-    scp = SelectedCompoundPairs(scores_selected, inchikeys14)
-        # Create generator
+        average_pairs_per_bin=1)
+    # Create generator
     test_generator = DataGeneratorCherrypicked(binned_spectrums=binned_spectrums,
                                                 spectrum_binner=ms2ds_binner,
                                                 selected_compound_pairs=scp,

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -120,13 +120,13 @@ def test_DataGeneratorCherrypicked():
         average_pairs_per_bin=1)
     # Create generator
     test_generator = DataGeneratorCherrypicked(binned_spectrums=binned_spectrums,
-                                                spectrum_binner=ms2ds_binner,
-                                                selected_compound_pairs=scp,
-                                                batch_size=batch_size,
-                                                augment_removal_max=0.0,
-                                                augment_removal_intensity=0.0,
-                                                augment_intensity=0.0,
-                                                augment_noise_max=0)
+                                               spectrum_binner=ms2ds_binner,
+                                               selected_compound_pairs=scp,
+                                               batch_size=batch_size,
+                                               augment_removal_max=0.0,
+                                               augment_removal_intensity=0.0,
+                                               augment_intensity=0.0,
+                                               augment_noise_max=0)
 
     x, y = test_generator.__getitem__(0)
     assert x[0].shape == x[1].shape == (batch_size, dimension), "Expected different data shape"

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -4,15 +4,15 @@ import pandas as pd
 import pytest
 from matchms import Spectrum
 from ms2deepscore import SpectrumBinner
-from ms2deepscore.data_generators import (DataGeneratorCherrypicked,
-                                          DataGeneratorAllInchikeys,
+from ms2deepscore.data_generators import (DataGeneratorAllInchikeys,
                                           DataGeneratorAllSpectrums,
+                                          DataGeneratorCherrypicked,
                                           _exclude_nans_from_labels,
                                           _validate_labels)
 from ms2deepscore.MetadataFeatureGenerator import (CategoricalToBinary,
                                                    StandardScaler)
-from ms2deepscore.spectrum_pair_selection import (compute_spectrum_pairs,
-    SelectedCompoundPairs)
+from ms2deepscore.spectrum_pair_selection import (SelectedCompoundPairs,
+                                                  compute_spectrum_pairs)
 from tests.test_user_worfklow import (get_reference_scores,
                                       load_processed_spectrums)
 

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -3,11 +3,12 @@ import pytest
 from scipy.sparse import coo_array
 from matchms import Spectrum
 from ms2deepscore.spectrum_pair_selection import (
-    compute_jaccard_similarity_matrix_cherrypicking,
     compute_spectrum_pairs,
     jaccard_similarity_matrix_cherrypicking,
     select_inchi_for_unique_inchikeys,
-    SelectedCompoundPairs
+    SelectedCompoundPairs,
+    try_cut_off,
+    find_correct_max_nr_of_pairs
     )
 
 
@@ -216,3 +217,15 @@ def test_SCP_generator(dummy_data):
     assert inchikey1 in inchikeys
     assert score in data
     assert inchikey2 in inchikeys
+
+
+def test_try_cut_off():
+    average_nr_of_pairs = try_cut_off([2, 5, 7],
+                                      4)
+    assert round(average_nr_of_pairs, 3) == round(3.3333333, 3)
+
+
+def test_find_correct_max_nr_of_pairs():
+    difference, correct_max_nr_of_pairs = find_correct_max_nr_of_pairs([2, 5, 7, 9], 3)
+    assert correct_max_nr_of_pairs == 4
+    assert difference == 2

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -3,8 +3,6 @@ import pytest
 from scipy.sparse import coo_array
 from matchms import Spectrum
 from ms2deepscore.spectrum_pair_selection import (
-    compute_spectrum_pairs,
-    jaccard_similarity_matrix_cherrypicking,
     select_inchi_for_unique_inchikeys,
     SelectedCompoundPairs,
     try_cut_off,
@@ -93,13 +91,14 @@ def test_compute_jaccard_similarity_per_bin_correct_counts(fingerprints):
     assert np.all(matrix_histogram[0] == expected_histogram)
 
 
-@pytest.mark.parametrize("average_pairs_per_bin", [1,2])
+@pytest.mark.parametrize("average_pairs_per_bin", [1, 2])
 def test_global_bias(fingerprints, average_pairs_per_bin):
     bins = np.array([(0, 0.35), (0.35, 0.65), (0.65, 1.0)])
-    selected_pairs_per_bin = jaccard_similarity_matrix_cherrypicking(fingerprints,
-                                                                     selection_bins=bins,
-                                                                     average_pairs_per_bin=average_pairs_per_bin,
-                                                                     max_oversampling_rate=8)
+
+    selected_pairs_per_bin = compute_jaccard_similarity_per_bin(fingerprints,
+                                                                selection_bins=bins,
+                                                                max_pairs_per_bin=10)
+    selected_pairs_per_bin = fix_bias(selected_pairs_per_bin, average_pairs_per_bin)
     matrix = convert_selected_pairs_per_bin_to_coo_array(selected_pairs_per_bin, fingerprints.shape[0])
     dense_matrix = matrix.todense()
     # Check if in each bin the nr of pairs is equal to the nr_of_fingerprints

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -1,16 +1,11 @@
 import numpy as np
 import pytest
-from scipy.sparse import coo_array
 from matchms import Spectrum
+from scipy.sparse import coo_array
 from ms2deepscore.spectrum_pair_selection import (
-    select_inchi_for_unique_inchikeys,
-    SelectedCompoundPairs,
-    try_cut_off,
-    find_correct_max_nr_of_pairs,
-    fix_bias,
-    compute_jaccard_similarity_per_bin,
-    convert_selected_pairs_per_bin_to_coo_array
-    )
+    SelectedCompoundPairs, compute_jaccard_similarity_per_bin,
+    convert_selected_pairs_per_bin_to_coo_array, find_correct_max_nr_of_pairs,
+    fix_bias, select_inchi_for_unique_inchikeys, try_cut_off)
 
 
 @pytest.fixture

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -164,6 +164,7 @@ def test_SCP_shuffle(dummy_data):
     original_cols = [r.copy() for r in scp._cols]
     original_scores = [s.copy() for s in scp._scores]
 
+    np.random.seed(7)
     scp.shuffle()
 
     # Check that the data has been shuffled


### PR DESCRIPTION
There is a risk of high fluctuation between the number of pairs in a bin per inchikey.

If you have 5 spectra in a row with no inchikey between 0.9 and 1.0 and the next spectrum has more than a 100, this implementation will result in 100 inchikeys for this inchikey even if the next inchikey also had more matches in this bin.

The behaviour I would prefer is, that it would increase the max bin for all other inchikeys (also the one already calculated). An option could be storing at first 2x max_pairs_per_bin if available and at the end after calculating all tanimoto scores determine how high the max_pair_per_bin should be to reach an average that matches the defined max_pair_per_bin.

This will be a bit more complex in implementation and result in a bit extra overhead and intermediate storage, but I think it is still doable and it reduces the risk of introducing other biases, like oversampling clusters with many similar inchikeys.
It also would make the resulting max_pairs_global be always 0 (unless there is a very extreme distribution).