### PR TITLE
Implement GeneratorSettings and implement in rest of code

### DIFF
--- a/ms2deepscore/data_generators.py
+++ b/ms2deepscore/data_generators.py
@@ -80,7 +80,8 @@ class GeneratorSettings:
                     raise ValueError(f"Unknown setting: {key}")
         self.validate_settings()
 
-        np.random.seed(self.random_seed)
+        if self.random_seed is not None:
+            np.random.seed(self.random_seed)
 
     def validate_settings(self):
         assert 0.0 <= self.augment_removal_max <= 1.0, "Expected value within [0,1]"

--- a/ms2deepscore/data_generators.py
+++ b/ms2deepscore/data_generators.py
@@ -1,6 +1,5 @@
 """ Data generators for training/inference with siamese Keras model.
 """
-import warnings
 from typing import Iterator, List, NamedTuple, Optional
 import numpy as np
 import pandas as pd
@@ -8,88 +7,8 @@ from tensorflow.keras.utils import Sequence  # pylint: disable=import-error
 from ms2deepscore.SpectrumBinner import SpectrumBinner
 from ms2deepscore.train_new_model.spectrum_pair_selection import \
     SelectedCompoundPairs
+from .train_new_model.SettingMS2Deepscore import GeneratorSettings
 from .typing import BinnedSpectrumType
-
-
-class GeneratorSettings:
-    """
-    Set parameters for data generator. Use below listed defaults unless other
-    input is provided.
-
-    Parameters
-    ----------
-    settings:
-        A dictionary containing the settings that need to be changed. For parameters that are not given the default
-        will be used.
-        batch_size
-            Number of pairs per batch. Default=32.
-        num_turns
-            Number of pairs for each InChiKey14 during each epoch. Default=1
-        shuffle
-            Set to True to shuffle IDs every epoch. Default=True
-        ignore_equal_pairs
-            Set to True to ignore pairs of two identical spectra. Default=True
-        same_prob_bins
-            List of tuples that define ranges of the true label to be trained with
-            equal frequencies. Default is set to [(0, 0.5), (0.5, 1)], which means
-            that pairs with scores <=0.5 will be picked as often as pairs with scores
-            > 0.5.
-        augment_removal_max
-            Maximum fraction of peaks (if intensity < below augment_removal_intensity)
-            to be removed randomly. Default is set to 0.2, which means that between
-            0 and 20% of all peaks with intensities < augment_removal_intensity
-            will be removed.
-        augment_removal_intensity
-            Specifying that only peaks with intensities < max_intensity will be removed.
-        augment_intensity
-            Change peak intensities by a random number between 0 and augment_intensity.
-            Default=0.1, which means that intensities are multiplied by 1+- a random
-            number within [0, 0.1].
-        augment_noise_max
-            Max number of 'new' noise peaks to add to the spectrum, between 0 to `augment_noise_max`
-            of peaks are added.
-        augment_noise_intensity
-            Intensity of the 'new' noise peaks to add to the spectrum
-        use_fixed_set
-            Toggles using a fixed dataset, if set to True the same dataset will be generated each
-            epoch. Default is False.
-        random_seed
-            Specify random seed for reproducible random number generation.
-        additional_inputs
-            Array of additional values to be used in training for e.g. ["precursor_mz", "parent_mass"]
-    """
-    def __init__(self, settings=None):
-        self.batch_size = 32
-        self.num_turns = 1
-        self.ignore_equal_pairs = True
-        self.shuffle = True
-        self.same_prob_bins = [(0, 0.5), (0.5, 1)]
-        self.augment_removal_max = 0.3
-        self.augment_removal_intensity = 0.2
-        self.augment_intensity = 0.4
-        self.augment_noise_max = 10
-        self.augment_noise_intensity = 0.01
-        self.use_fixed_set = False
-        self.random_seed = None
-        if settings:
-            for key, value in settings.items():
-                if hasattr(self, key):
-                    print(f"The value for {key} is set from {getattr(self, key)} (default) to {value}")
-                    setattr(self, key, value)
-                else:
-                    raise ValueError(f"Unknown setting: {key}")
-        self.validate_settings()
-
-        if self.random_seed is not None:
-            np.random.seed(self.random_seed)
-
-    def validate_settings(self):
-        assert 0.0 <= self.augment_removal_max <= 1.0, "Expected value within [0,1]"
-        assert 0.0 <= self.augment_removal_intensity <= 1.0, "Expected value within [0,1]"
-        if self.use_fixed_set and self.shuffle:
-            warnings.warn('When using a fixed set, data will not be shuffled')
-        if self.random_seed is not None:
-            assert isinstance(self.random_seed, int), "Random seed must be integer number."
 
 
 class SpectrumPair(NamedTuple):
@@ -501,23 +420,6 @@ class DataGeneratorCherrypicked(DataGeneratorBase):
         self.fixed_set = {}
         self.selected_compound_pairs = selected_compound_pairs
         self.on_epoch_end()
-
-    def __getitem__(self, batch_index: int):
-        """Generate one batch of data.
-
-        If use_fixed_set=True we try retrieving the batch from self.fixed_set (or store it if
-        this is the first epoch). This ensures a fixed set of data is generated each epoch.
-        """
-        if self.settings.use_fixed_set and batch_index in self.fixed_set:
-            return self.fixed_set[batch_index]
-        if self.settings.random_seed is not None and batch_index == 0:
-            np.random.seed(self.settings.random_seed)
-        spectrum_pairs = self._spectrum_pair_generator(batch_index)
-        X, y = self._data_generation(spectrum_pairs)
-        if self.settings.use_fixed_set:
-            # Store batches for later epochs
-            self.fixed_set[batch_index] = (X, y)
-        return X, y
 
     def __len__(self):
         return int(self.settings.num_turns)\

--- a/ms2deepscore/data_generators.py
+++ b/ms2deepscore/data_generators.py
@@ -479,24 +479,8 @@ class DataGeneratorCherrypicked(DataGeneratorBase):
             respective similarity scores.
         spectrum_binner
             SpectrumBinner which was used to convert the data to the binned_spectrums.
-        As part of **settings, defaults for the following parameters can be set:
-        batch_size
-            Number of pairs per batch. Default=32.
-        num_turns
-            Number of pairs for each InChiKey during each epoch. Default=1.
-        shuffle
-            Set to True to shuffle IDs every epoch. Default=True
-        augment_removal_max
-            Maximum fraction of peaks (if intensity < below augment_removal_intensity)
-            to be removed randomly. Default is set to 0.2, which means that between
-            0 and 20% of all peaks with intensities < augment_removal_intensity
-            will be removed.
-        augment_removal_intensity
-            Specifying that only peaks with intensities < max_intensity will be removed.
-        augment_intensity
-            Change peak intensities by a random number between 0 and augment_intensity.
-            Default=0.1, which means that intensities are multiplied by 1+- a random
-            number within [0, 0.1].
+        settings
+            The available settings can be found in GeneratorSettings
         """
         self.binned_spectrums = binned_spectrums
         # Collect all inchikeys

--- a/ms2deepscore/train_new_model/train_ms2deepscore.py
+++ b/ms2deepscore/train_new_model/train_ms2deepscore.py
@@ -86,9 +86,6 @@ def train_ms2ds_model(
 
     training_generator = DataGeneratorCherrypicked(
         binned_spectrums_training,
-        selected_inchikeys=list(
-            {s.get("inchikey")[:14] for s in binned_spectrums_training}
-        ),
         selected_compound_pairs=selected_compound_pairs_training,
         spectrum_binner=spectrum_binner,
         num_turns=2,
@@ -99,7 +96,6 @@ def train_ms2ds_model(
 
     validation_generator = DataGeneratorCherrypicked(
         binned_spectrums_val,
-        selected_inchikeys=list({s.get("inchikey")[:14] for s in binned_spectrums_val}),
         selected_compound_pairs=selected_compound_pair_val,
         spectrum_binner=spectrum_binner,
         num_turns=10,  # Number of pairs for each InChiKey14 during each epoch.

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -204,7 +204,6 @@ def test_DataGeneratorAllSpectrums():
     # Define other parameters
     batch_size = 8 # Set the batch size to 8 to make sure it is a different number than the number of bins.
     dimension = len(ms2ds_binner.known_bins)
-    np.random.seed(41) #Set the seed to make sure multiple spectra are selected every time.
     # Create generator
     test_generator = DataGeneratorAllSpectrums(binned_spectrums=binned_spectrums,
                                                reference_scores_df=tanimoto_scores_df,
@@ -213,7 +212,8 @@ def test_DataGeneratorAllSpectrums():
                                                augment_removal_max=0.0,
                                                augment_removal_intensity=0.0,
                                                augment_intensity=0.0,
-                                               augment_noise_max=0)
+                                               augment_noise_max=0,
+                                               random_seed=41)
 
     x, y = test_generator.__getitem__(0)
     assert x[0].shape == x[1].shape == (batch_size, dimension), "Expected different data shape"

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -205,10 +205,8 @@ def test_DataGeneratorAllSpectrums():
     batch_size = 8 # Set the batch size to 8 to make sure it is a different number than the number of bins.
     dimension = len(ms2ds_binner.known_bins)
     np.random.seed(41) #Set the seed to make sure multiple spectra are selected every time.
-    selected_inchikeys = tanimoto_scores_df.index
     # Create generator
     test_generator = DataGeneratorAllSpectrums(binned_spectrums=binned_spectrums,
-                                               selected_inchikeys=selected_inchikeys,
                                                reference_scores_df=tanimoto_scores_df,
                                                spectrum_binner=ms2ds_binner,
                                                batch_size=batch_size,
@@ -259,8 +257,8 @@ def test_DataGeneratorAllInchikeys_real_data():
     A, B = test_generator.__getitem__(0)
     assert A[0].shape == A[1].shape == (batch_size, dimension), "Expected different data shape"
     assert B.shape[0] == 10, "Expected different label shape."
-    assert test_generator.settings["num_turns"] == 1, "Expected different default."
-    assert test_generator.settings["augment_intensity"] == 0.0, "Expected changed value."
+    assert test_generator.settings.num_turns == 1, "Expected different default."
+    assert test_generator.settings.augment_intensity == 0.0, "Expected changed value."
 
 
 def test_DataGeneratorAllSpectrumsRealData():
@@ -283,8 +281,8 @@ def test_DataGeneratorAllSpectrumsRealData():
     A, B = test_generator.__getitem__(0)
     assert A[0].shape == A[1].shape == (10, dimension), "Expected different data shape"
     assert B.shape[0] == 10, "Expected different label shape."
-    assert test_generator.settings["num_turns"] == 1, "Expected different default."
-    assert test_generator.settings["augment_intensity"] == 0.0, "Expected changed value."
+    assert test_generator.settings.num_turns == 1, "Expected different default."
+    assert test_generator.settings.augment_intensity == 0.0, "Expected changed value."
 
 
 def test_DataGeneratorAllSpectrums_no_inchikey_leaking():
@@ -364,7 +362,7 @@ def test_DataGeneratorAllSpectrums_fixed_set():
     second_X, second_y = collect_results(fixed_generator, batch_size, dimension)
     assert np.array_equal(first_X, second_X)
     assert np.array_equal(first_y, second_y)
-    assert fixed_generator.settings["random_seed"] is None
+    assert fixed_generator.settings.random_seed is None
 
 
 def test_DataGeneratorAllSpectrums_fixed_set_random_seed():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,7 +63,7 @@ def test_siamese_model():
     X, y = test_generator.__getitem__(0)
     embeddings = model.base.predict(X[0])
     assert isinstance(embeddings, np.ndarray), "Expected numpy array"
-    assert embeddings.shape[0] == test_generator.settings["batch_size"] == 32, \
+    assert embeddings.shape[0] == test_generator.settings.batch_size == 32, \
         "Expected different batch size"
     assert embeddings.shape[1] == model.base.output_shape[1] == 200, \
         "Expected different embedding size"
@@ -117,7 +117,7 @@ def test_load_model():
     X, y = test_generator.__getitem__(0)
     embeddings = model.base.predict(X[0])
     assert isinstance(embeddings, np.ndarray), "Expected numpy array"
-    assert embeddings.shape[0] == test_generator.settings["batch_size"] == 32, \
+    assert embeddings.shape[0] == test_generator.settings.batch_size == 32, \
         "Expected different batch size"
     assert embeddings.shape[1] == model.base.output_shape[1] == 200, \
         "Expected different embedding size"
@@ -162,7 +162,7 @@ def get_test_binner_and_generator_additional_inputs():
 
     dimension = len(spectrum_binner.known_bins)
     data_generator = DataGeneratorAllSpectrums(binned_spectrums, tanimoto_scores_df,
-                                               spectrum_binner=spectrum_binner, additional_input=additional_inputs)
+                                               spectrum_binner=spectrum_binner)
 
     # Create generator
     return spectrum_binner, data_generator

--- a/tests/test_training_wrapper_function.py
+++ b/tests/test_training_wrapper_function.py
@@ -7,7 +7,6 @@ from ms2deepscore.train_new_model.SettingMS2Deepscore import \
     SettingsMS2Deepscore
 from ms2deepscore.train_new_model.training_wrapper_functions import \
     train_ms2deepscore_wrapper
-                                                      
 
 
 TEST_RESOURCES_PATH = Path(__file__).parent / 'resources'


### PR DESCRIPTION
Implements a GeneratorSettings class.
This makes it easier to refactor later if we want to change a settings name. 

During implementation I noticed we did not check before that the settings given are actually used, this resulted in us passing values to generators that were long outdated without getting a warning. 