### PR TITLE
Small fixes

### DIFF
--- a/ms2deepscore/MetadataFeatureGenerator.py
+++ b/ms2deepscore/MetadataFeatureGenerator.py
@@ -82,7 +82,7 @@ class StandardScaler(MetadataFeatureGenerator):
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
         assert self.metadata_field is not None, f"Metadata entry for {self.metadata_field} is missing."
-        assert isinstance(feature, (int, float))
+        assert isinstance(feature, (int, float)), f"Expected float or int, got {feature}, for {self.metadata_field}"
         if self.standard_deviation:
             return (feature - self.mean) / self.standard_deviation
         return feature - self.mean

--- a/ms2deepscore/MetadataFeatureGenerator.py
+++ b/ms2deepscore/MetadataFeatureGenerator.py
@@ -81,8 +81,10 @@ class StandardScaler(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        assert self.metadata_field is not None, f"Metadata entry for {self.metadata_field} is missing."
-        assert isinstance(feature, (int, float)), f"Expected float or int, got {feature}, for {self.metadata_field}"
+        if self.metadata_field is None:
+            raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
+        if not isinstance(feature, (int, float)):
+            raise TypeError(f"Expected float or int, got {feature}, for {self.metadata_field}")
         if self.standard_deviation:
             return (feature - self.mean) / self.standard_deviation
         return feature - self.mean
@@ -104,7 +106,8 @@ class OneHotEncoder(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        assert self.metadata_field is not None, f"Metadata entry for {self.metadata_field} is missing."
+        if self.metadata_field is None:
+            raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature == self.entries_becoming_one:
             return 1
         return 0
@@ -135,12 +138,13 @@ class CategoricalToBinary(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        assert self.metadata_field is not None, f"Metadata entry for {self.metadata_field} is missing."
+        if self.metadata_field is None:
+            raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature in self.entries_becoming_one:
             return 1
         if feature in self.entries_becoming_zero:
             return 0
-        assert False, f"Feature should be {self.entries_becoming_one} or {self.entries_becoming_zero}, not {feature}"
+        raise ValueError(f"Feature should be {self.entries_becoming_one} or {self.entries_becoming_zero}, not {feature}")
 
     @classmethod
     def load_from_dict(cls, json_dict: dict):
@@ -164,6 +168,7 @@ def load_from_json(list_of_json_metadata_feature_generators: List[Tuple[str, dic
     for class_name, settings in list_of_json_metadata_feature_generators:
         # loads in all the classes in MetadataFeatureGenerator.py
         metadata_class = getattr(possible_metadata_classes, class_name)
-        assert issubclass(metadata_class, MetadataFeatureGenerator), "Unknown feature generator class."
+        if not issubclass(metadata_class, MetadataFeatureGenerator):
+            raise TypeError("Unknown feature generator class.")
         metadata_feature_generator_list.append(metadata_class.load_from_dict(settings))
     return tuple(metadata_feature_generator_list)

--- a/ms2deepscore/benchmarking/plot_rmse_per_bin.py
+++ b/ms2deepscore/benchmarking/plot_rmse_per_bin.py
@@ -6,7 +6,10 @@ from ms2deepscore.models.loss_functions import bin_dependent_losses
 def plot_rmse_per_bin(predicted_scores, true_scores,
                       ref_score_bins=np.array([(x / 10, x / 10 + 0.1) for x in range(0, 10)])):
     bin_content, bounds, losses = bin_dependent_losses(
-        predicted_scores, true_scores, ref_score_bins, loss_types=["rmse"]
+        predictions=predicted_scores,
+        true_values=true_scores,
+        ref_score_bins=ref_score_bins,
+        loss_types=["rmse"]
         )
     rmses = losses["rmse"]
     _, (ax1, ax2) = plt.subplots(2, 1, sharex=True, figsize=(4, 5), dpi=120)
@@ -30,7 +33,7 @@ def plot_rmse_per_bin(predicted_scores, true_scores,
 def plot_rmse_per_bin_multiple_benchmarks(list_of_predicted_scores,
                                           list_of_true_values,
                                           labels,
-                                          ref_score_bins = np.array([(x / 10, x / 10 + 0.1) for x in range(0, 10)])):
+                                          ref_score_bins=np.array([(x / 10, x / 10 + 0.1) for x in range(0, 10)])):
     """Combines the plot of multiple comparisons into one plot
 
     """

--- a/ms2deepscore/train_new_model/spectrum_pair_selection.py
+++ b/ms2deepscore/train_new_model/spectrum_pair_selection.py
@@ -292,7 +292,8 @@ def compute_fingerprints_for_training(spectrums,
         raise ValueError("No spectra were selected to calculate fingerprints")
 
     spectra_selected, inchikeys14_unique = select_inchi_for_unique_inchikeys(spectrums)
-    print(f"Selected {len(spectra_selected)} spectra with unique inchikeys (out of {len(spectrums)} spectra)")
+    print(f"Selected {len(spectra_selected)} spectra with unique inchikeys for calculating tanimoto scores "
+          f"(out of {len(spectrums)} spectra)")
 
     # Compute fingerprints using matchms
     spectra_selected = [add_fingerprint(s, fingerprint_type, nbits)\

--- a/ms2deepscore/utils.py
+++ b/ms2deepscore/utils.py
@@ -33,7 +33,7 @@ def return_non_existing_file_name(file_name):
 
 
 def load_spectra_as_list(file_name) -> List[Spectrum]:
-    spectra = load_spectra(file_name, metadata_harmonization=False)
+    spectra = load_spectra(file_name, metadata_harmonization=True)
     if isinstance(spectra, Generator):
         return list(spectra)
     return spectra

--- a/ms2deepscore/wrapper_functions/training_wrapper_functions.py
+++ b/ms2deepscore/wrapper_functions/training_wrapper_functions.py
@@ -67,7 +67,7 @@ def create_model_directory_name(settings: SettingsMS2Deepscore):
     """Creates a directory name using metadata, it will contain the metadata, the binned spectra and final model"""
     binning_file_label = ""
     for metadata_generator in settings.additional_metadata:
-        binning_file_label += metadata_generator.metadata_field + "_"
+        binning_file_label += metadata_generator[1]["metadata_field"] + "_"
 
     # Define a neural net structure label
     neural_net_structure_label = ""
@@ -136,7 +136,7 @@ class StoreTrainingData:
         assert not os.path.isfile(self.positive_mode_spectra_file), "the positive mode spectra file already exists"
         assert not os.path.isfile(self.negative_mode_spectra_file), "the negative mode spectra file already exists"
         positive_mode_spectra, negative_mode_spectra = split_by_ionmode(
-            load_spectra(self.spectra_file_name, metadata_harmonization=False))
+            load_spectra(self.spectra_file_name, metadata_harmonization=True))
         save_spectra(positive_mode_spectra, self.positive_mode_spectra_file)
         save_spectra(negative_mode_spectra, self.negative_mode_spectra_file)
         return positive_mode_spectra, negative_mode_spectra


### PR DESCRIPTION
Almost no functional change except for fixing some bugs with the metadataGenerator integration.
- For the model file name generation, the way we store the metadataGenerator slightly changed, was adjusted accordingly in the pipeline.
- I enabled metadata harmonization again when loading spectra. Otherwise, the precursor mz is stored as string which breaks the metadata generator. Metadata harmonization was disabled before, because it would use pepmass to overwrite previously fixed precursor mz. But I believe this was fixed with a newer version of matchms.