### PR TITLE
Type check settings

### DIFF
--- a/ms2deepscore/SettingsMS2Deepscore.py
+++ b/ms2deepscore/SettingsMS2Deepscore.py
@@ -115,7 +115,7 @@ class SettingsMS2Deepscore:
         self.max_mz = 1000
         self.mz_bin_width = 0.1
         self.intensity_scaling = 0.5
-        self.additional_metadata = ()
+        self.additional_metadata = []
 
         # Data generator settings
         self.batch_size = 32

--- a/ms2deepscore/SettingsMS2Deepscore.py
+++ b/ms2deepscore/SettingsMS2Deepscore.py
@@ -115,7 +115,7 @@ class SettingsMS2Deepscore:
         self.max_mz = 1000
         self.mz_bin_width = 0.1
         self.intensity_scaling = 0.5
-        self.additional_metadata = []
+        self.additional_metadata = ()
 
         # Data generator settings
         self.batch_size = 32
@@ -145,7 +145,7 @@ class SettingsMS2Deepscore:
         if settings:
             for key, value in settings.items():
                 if hasattr(self, key):
-                    if not isinstance(value, type(getattr(self, key))):
+                    if not isinstance(value, type(getattr(self, key))) and not getattr(self, key) is None:
                         raise TypeError(f"An unexpected type is given for the setting: {key}. "
                                         f"The expected type is {type(getattr(self, key))}, "
                                         f"the type given is {type(value)}, the value given is {value}")

--- a/ms2deepscore/SettingsMS2Deepscore.py
+++ b/ms2deepscore/SettingsMS2Deepscore.py
@@ -98,10 +98,10 @@ class SettingsMS2Deepscore:
         self.train_binning_layer_output_per_group: int = 2
 
         # training settings
-        self.dropout_rate = 0.2
+        self.dropout_rate = 0.0
         self.learning_rate = 0.00025
         self.epochs = 250
-        self.patience = 30
+        self.patience = 20
         self.loss_function = "mse"
         self.weighting_factor = 0
 

--- a/ms2deepscore/SettingsMS2Deepscore.py
+++ b/ms2deepscore/SettingsMS2Deepscore.py
@@ -145,6 +145,10 @@ class SettingsMS2Deepscore:
         if settings:
             for key, value in settings.items():
                 if hasattr(self, key):
+                    if not isinstance(value, type(getattr(self, key))):
+                        raise TypeError(f"An unexpected type is given for the setting: {key}. "
+                                        f"The expected type is {type(getattr(self, key))}, "
+                                        f"the type given is {type(value)}, the value given is {value}")
                     setattr(self, key, value)
                 else:
                     raise ValueError(f"Unknown setting: {key}")

--- a/tests/test_SettingsMS2deepscore.py
+++ b/tests/test_SettingsMS2deepscore.py
@@ -16,6 +16,11 @@ def test_set_unknown_settings():
         SettingsMS2Deepscore(**{"test_case": 123})
 
 
+def test_set_wrong_type_settings():
+    with pytest.raises(TypeError):
+        SettingsMS2Deepscore(**{"base_dims": 123})
+
+
 def test_save_settings(tmp_path):
     settings = SettingsMS2Deepscore(epochs=200,
                                     base_dims=(200,200))

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -80,7 +80,7 @@ def test_tensorize_spectra():
                                     max_mz=1000,
                                     mz_bin_width=1.0,
                                     intensity_scaling=0.5,
-                                    additional_metadata=())
+                                    additional_metadata=[])
     spec_tensors, meta_tensors = tensorize_spectra([spectrum, spectrum], settings)
 
     assert meta_tensors.shape == torch.Size([2, 0])
@@ -99,7 +99,7 @@ def test_DataGeneratorPytorch():
                                     max_mz=1000,
                                     mz_bin_width=0.1,
                                     intensity_scaling=0.5,
-                                    additional_metadata=(),
+                                    additional_metadata=[],
                                     same_prob_bins=np.array([(x / 4, x / 4 + 0.25) for x in range(0, 4)]),
                                     average_pairs_per_bin=1,
                                     batch_size=batch_size,

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -78,7 +78,7 @@ def test_tensorize_spectra():
     spectrum = Spectrum(mz=np.array([10, 500, 999.9]), intensities=np.array([0.5, 0.5, 1]))
     settings = SettingsMS2Deepscore(min_mz=10,
                                     max_mz=1000,
-                                    mz_bin_width=1,
+                                    mz_bin_width=1.0,
                                     intensity_scaling=0.5,
                                     additional_metadata=())
     spec_tensors, meta_tensors = tensorize_spectra([spectrum, spectrum], settings)

--- a/tests/test_siamese_spectra_model.py
+++ b/tests/test_siamese_spectra_model.py
@@ -57,7 +57,7 @@ def simple_training_spectra():
 
 
 def test_siamese_model_forward_pass(dummy_spectra):
-    model_settings = SettingsMS2Deepscore(mz_bin_width=1,)
+    model_settings = SettingsMS2Deepscore(mz_bin_width=1.0,)
     model = SiameseSpectralModel(model_settings)
     spec_tensors, meta_tensors = tensorize_spectra(dummy_spectra, model_settings)
     similarity_score = model(spec_tensors, spec_tensors, meta_tensors, meta_tensors)
@@ -65,7 +65,7 @@ def test_siamese_model_forward_pass(dummy_spectra):
 
 
 def test_siamese_model_no_binning_layer(dummy_spectra):
-    model_settings = SettingsMS2Deepscore(mz_bin_width=1,)
+    model_settings = SettingsMS2Deepscore(mz_bin_width=1.0,)
     model = SiameseSpectralModel(model_settings)
     assert not model.model_settings.train_binning_layer
 

--- a/tests/test_train_ms2deepscore.py
+++ b/tests/test_train_ms2deepscore.py
@@ -20,7 +20,7 @@ def test_train_ms2ds_model(tmp_path):
     settings = SettingsMS2Deepscore(**{
         "mz_bin_width": 1.0,
         "epochs": 2,  # to speed up tests --> usually many more
-        "base_dims": [100, 100],  # to speed up tests --> usually larger
+        "base_dims": (100, 100),  # to speed up tests --> usually larger
         "embedding_dim": 50,  # to speed up tests --> usually larger
         "same_prob_bins": np.array([(0, 0.5), (0.5, 1.0)]),
         "average_pairs_per_bin": 2,

--- a/tests/test_training_wrapper_function.py
+++ b/tests/test_training_wrapper_function.py
@@ -18,7 +18,7 @@ def test_train_wrapper_ms2ds_model(tmp_path):
     settings = SettingsMS2Deepscore(**{
         "epochs": 2,  # to speed up tests --> usually many more
         "ionisation_mode": "negative",
-        "base_dims": [200, 200],  # to speed up tests --> usually larger
+        "base_dims": (200, 200),  # to speed up tests --> usually larger
         "embedding_dim": 100,  # to speed up tests --> usually larger
         "same_prob_bins": np.array([(0, 0.2), (0.2, 1.0)]),
         "average_pairs_per_bin": 2,


### PR DESCRIPTION
Added a quick check to check that the settings are of the correct type (the same as the default).

I did accidentally switch two settings and it only breaks after calculating all tanimoto scores, which is a bit annoying. 

There were two issues I had to fix:
- random_seed is normally None (and int is expected)
- For additional metadata a list or tuple, does not matter, but now is fixed. 

Both are fixed now. But the list requirement for additional metadata is now fixed. Do you think that is okay? Or shall we remove the type check? 

Alternatively I could write a quick function that does checks for iterables instead of just checking the type. 