### PR TITLE
Fix selected compound pairs bug

### DIFF
--- a/ms2deepscore/train_new_model/data_generators.py
+++ b/ms2deepscore/train_new_model/data_generators.py
@@ -87,7 +87,10 @@ class DataGeneratorPytorch:
         indexes = self.indexes[batch_index * batch_size:(batch_index + 1) * batch_size]
         for index in indexes:
             inchikey1 = self.selected_compound_pairs.idx_to_inchikey[index]
-            score, inchikey2 = self.selected_compound_pairs.next_pair_for_inchikey(inchikey1)
+            result = self.selected_compound_pairs.next_pair_for_inchikey(inchikey1)
+            if result is None:
+                continue
+            score, inchikey2 = result
             spectrum1 = self._get_spectrum_with_inchikey(inchikey1)
             spectrum2 = self._get_spectrum_with_inchikey(inchikey2)
             yield (spectrum1, spectrum2, score)

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -218,6 +218,18 @@ def test_SCP_next_pair_for_inchikey(dummy_data):
     assert inchikey2 == "Inchikey2"
 
 
+def test_SCP_next_pair_for_inchikey_with_no_pairs(dummy_data):
+    """It is possible that a inchikey does not have any available pairs. This can be the case if this inchikey already
+    appears very frequently in the list of pairs for other inchikeys. In this way the inchikey still appears frequently,
+    but does not have any inchikey to select. """
+    data, row, col, inchikeys = dummy_data
+    coo = coo_array((data, (row, col)))
+    scp = SelectedCompoundPairs(coo, inchikeys, shuffling=False)
+
+    result = scp.next_pair_for_inchikey("Inchikey2")
+    assert result is None
+
+
 def test_SCP_generator(dummy_data):
     data, row, col, inchikeys = dummy_data
     coo = coo_array((data, (row, col)))

--- a/tests/test_spectrum_pair_selection.py
+++ b/tests/test_spectrum_pair_selection.py
@@ -207,12 +207,12 @@ def test_SCP_next_pair_for_inchikey(dummy_data):
     assert inchikey2 == "Inchikey2"
 
     score, inchikey2 = scp.next_pair_for_inchikey("Inchikey1")
-    assert scp._row_generator_index[1] == 2
+    assert scp._row_pair_counter[1] == 2
     assert score == 0.3
     assert inchikey2 == "Inchikey3"
 
     # Test wrap around
-    scp._row_generator_index[1] = 0
+    scp._row_pair_counter[1] = 0
     score, inchikey2 = scp.next_pair_for_inchikey("Inchikey1")
     assert score == 0.7
     assert inchikey2 == "Inchikey2"


### PR DESCRIPTION
When having smaller datasets there is a chance that a inchikey does not have available pairs in the datagenerator. This will result in an index out of bound error. This can happen because an inchikey can already occur frequently in the list of inchikeys to be selected by other pairs. Here we implemented a test and skip empty pair lists for inchikeys. 

This happens during the function balanced_selection if the minimum number of pairs per bin is < number of inchikeys. This is the case for the validation set. Nr of inchikeys is 1699, but min pairs per bin (0.8-0.9 tanimoto) is 944. This means that for all the bins only 944 pairs are selected. So each inchikey starts with 0 pairs that are than filled. By chance it can happen that one inchikey is selected 0 times. 

As long as the number of pairs per bin is quite a bit higher than the number of inchikeys this leads to quite a good balancing of the inchikeys. The inchikey balancing will become better if we set max_oversampling rate to a higher number. 