### PR TITLE
Fix deprecated Node20 for checkout and setup-python

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'macos-14']
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
         exclude:
           # already tested in first_check job
           - python-version: 3.12

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -11,9 +11,9 @@ jobs:
     name: Thorough code check / python-3.12 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Python info
@@ -50,9 +50,9 @@ jobs:
           - python-version: 3.12
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info

--- a/.github/workflows/CI_publish_pypi.yml
+++ b/.github/workflows/CI_publish_pypi.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install dependencies

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0


### PR DESCRIPTION
Fixes https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/