### PR TITLE
Refactor for compatibility with upcoming matchms 1.0

### DIFF
--- a/ms2deepscore/MS2DeepScore.py
+++ b/ms2deepscore/MS2DeepScore.py
@@ -1,13 +1,21 @@
 from typing import List
+
 import numpy as np
 from matchms import Spectrum
-from matchms.similarity.BaseSimilarity import BaseSimilarity
+
+from ms2deepscore.matchms_compat import (
+    MATCHMS_V1_API,
+    BaseSimilarity,
+    as_matchms_scores,
+    normalize_score_fields,
+    assert_legacy_symmetric_inputs,
+)
 from ms2deepscore.models.SiameseSpectralModel import SiameseSpectralModel
 from .vector_operations import cosine_similarity, cosine_similarity_matrix
 
 
 class MS2DeepScore(BaseSimilarity):
-    """Calculate MS2DeepScore similarity scores between a reference and a query.
+    """Calculate MS2DeepScore similarity scores between spectra.
 
     Using a trained model, binned spectrums will be converted into spectrum
     vectors using a deep neural network. The MS2DeepScore similarity is then
@@ -19,13 +27,13 @@ class MS2DeepScore(BaseSimilarity):
     .. code-block:: python
 
         from matchms import calculate_scores()
-        from matchms.importing import load_from_json
+        from matchms.importing import load_ms2_dataset
         from ms2deepscore import MS2DeepScore
         from ms2deepscore.models import load_model
 
         # Import data
-        references = load_from_json("abc.json")
-        queries = load_from_json("xyz.json")
+        references = load_ms2_dataset("abc.mgf")
+        queries = load_ms2_dataset("xyz.mgf")
 
         # Load pretrained model
         model = load_model("model_file_123.pt")
@@ -34,8 +42,11 @@ class MS2DeepScore(BaseSimilarity):
         # Calculate scores and get matchms.Scores object
         scores = calculate_scores(references, queries, similarity_measure)
 
-
+    This implementation supports both the matchms <=0.33 matrix API (NumPy
+    return values) and the matchms >=1.0 API (``matchms.Scores`` return values).
     """
+
+    score_fields = ("score",)
 
     def __init__(self, model: SiameseSpectralModel, progress_bar: bool = True):
         """
@@ -54,17 +65,24 @@ class MS2DeepScore(BaseSimilarity):
         self.output_vector_dim = self.model.model_settings.embedding_dim
         self.progress_bar = progress_bar
 
-    def get_embedding_array(self, spectrums, datatype: str = "numpy", batch_size: int = 1024) -> np.ndarray:
-        """Calculate the spectrum embeddings for a list of spectrums."""
+    def get_embedding_array(
+        self,
+        spectra,
+        datatype: str = "numpy",
+        batch_size: int = 1024,
+        progress_bar: bool | None = None,
+    ) -> np.ndarray:
+        """Calculate embeddings for a collection of spectra."""
+        show_progress = self.progress_bar if progress_bar is None else progress_bar
         return self.model.compute_embedding_array(
-            spectrums,
+            spectra,
             datatype=datatype,
-            progress_bar=self.progress_bar,
-            batch_size=batch_size
-            )
+            progress_bar=show_progress,
+            batch_size=batch_size,
+        )
 
     def pair(self, reference: Spectrum, query: Spectrum) -> float:
-        """Calculate the MS2DeepScore similaritiy between a reference and a query spectrum.
+        """Calculate a single MS2DeepScore similarity.
 
         Parameters
         ----------
@@ -78,13 +96,17 @@ class MS2DeepScore(BaseSimilarity):
         ms2ds_similarity
             MS2DeepScore similarity score.
         """
-        embedding_reference = self.get_embedding_array([reference])
-        embedding_query = self.get_embedding_array([query])
-        return cosine_similarity(embedding_reference[0, :], embedding_query[0, :])
+        embeddings = self.get_embedding_array([reference, query])
+        return cosine_similarity(embeddings[0, :], embeddings[1, :])
 
-    def matrix(self, references: List[Spectrum], queries: List[Spectrum],
-               array_type: str = "numpy",
-               is_symmetric: bool = False) -> np.ndarray:
+    def _matrix_numpy(
+        self,
+        references: List[Spectrum],
+        queries: List[Spectrum],
+        *,
+        is_symmetric: bool,
+        progress_bar: bool,
+    ) -> np.ndarray:
         """Calculate the MS2DeepScore similarities between all references and queries.
 
         Parameters
@@ -106,13 +128,56 @@ class MS2DeepScore(BaseSimilarity):
         ms2ds_similarity
             Array of MS2DeepScore similarity scores.
         """
-        embeddings_reference = self.get_embedding_array(references)
+        embeddings_reference = self.get_embedding_array(
+            references, progress_bar=progress_bar
+        )
         if is_symmetric:
-            assert np.all(references == queries), \
-                "Expected references to be equal to queries for is_symmetric=True"
             embeddings_query = embeddings_reference
         else:
-            embeddings_query = self.get_embedding_array(queries)
+            embeddings_query = self.get_embedding_array(
+                queries, progress_bar=progress_bar
+            )
+        return cosine_similarity_matrix(embeddings_reference, embeddings_query)
 
-        ms2ds_similarity = cosine_similarity_matrix(embeddings_reference, embeddings_query)
-        return ms2ds_similarity
+    if MATCHMS_V1_API:
+
+        def matrix(
+            self,
+            spectra_1: List[Spectrum],
+            spectra_2: List[Spectrum] | None = None,
+            score_fields=None,
+            progress_bar: bool = True,
+        ):
+            """Return a matchms >=1.0 ``Scores`` object."""
+            normalize_score_fields(score_fields, self.score_fields)
+            is_symmetric = spectra_2 is None or spectra_2 is spectra_1
+            queries = spectra_1 if spectra_2 is None else spectra_2
+            score_matrix = self._matrix_numpy(
+                spectra_1,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+            )
+            return as_matchms_scores({"score": score_matrix})
+
+    else:
+
+        def matrix(
+            self,
+            references: List[Spectrum],
+            queries: List[Spectrum],
+            array_type: str = "numpy",
+            is_symmetric: bool = False,
+            progress_bar: bool = True,
+        ) -> np.ndarray:
+            """Return a NumPy matrix for the matchms <=0.33 API."""
+            if array_type != "numpy":
+                raise NotImplementedError("MS2DeepScore currently supports only array_type='numpy'.")
+            if is_symmetric:
+                assert_legacy_symmetric_inputs(references, queries)
+            return self._matrix_numpy(
+                references,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+            )

--- a/ms2deepscore/MS2DeepScore.py
+++ b/ms2deepscore/MS2DeepScore.py
@@ -5,11 +5,14 @@ from matchms import Spectrum
 
 from ms2deepscore.matchms_compat import (
     MATCHMS_V1_API,
-    BaseSimilarity,
     as_matchms_scores,
     normalize_score_fields,
     assert_legacy_symmetric_inputs,
 )
+if MATCHMS_V1_API:
+    from matchms.similarity.base_similarity import BaseSimilarity
+else:
+    from matchms.similarity.BaseSimilarity import BaseSimilarity
 from ms2deepscore.models.SiameseSpectralModel import SiameseSpectralModel
 from .vector_operations import cosine_similarity, cosine_similarity_matrix
 

--- a/ms2deepscore/MS2DeepScoreEvaluated.py
+++ b/ms2deepscore/MS2DeepScoreEvaluated.py
@@ -5,11 +5,14 @@ from matchms import Spectrum
 
 from ms2deepscore.matchms_compat import (
     MATCHMS_V1_API,
-    BaseSimilarity,
     as_matchms_scores,
     normalize_score_fields,
     assert_legacy_symmetric_inputs,
 )
+if MATCHMS_V1_API:
+    from matchms.similarity.base_similarity import BaseSimilarity
+else:
+    from matchms.similarity.BaseSimilarity import BaseSimilarity
 from ms2deepscore.models.LinearEmbeddingEvaluation import compute_error_predictions
 from ms2deepscore.models.SiameseSpectralModel import SiameseSpectralModel
 from ms2deepscore.vector_operations import cosine_similarity, cosine_similarity_matrix

--- a/ms2deepscore/MS2DeepScoreEvaluated.py
+++ b/ms2deepscore/MS2DeepScoreEvaluated.py
@@ -1,23 +1,31 @@
 from typing import List
+
 import numpy as np
 from matchms import Spectrum
-from matchms.similarity.BaseSimilarity import BaseSimilarity
-from ms2deepscore.models.LinearEmbeddingEvaluation import \
-    compute_error_predictions
+
+from ms2deepscore.matchms_compat import (
+    MATCHMS_V1_API,
+    BaseSimilarity,
+    as_matchms_scores,
+    normalize_score_fields,
+    assert_legacy_symmetric_inputs,
+)
+from ms2deepscore.models.LinearEmbeddingEvaluation import compute_error_predictions
 from ms2deepscore.models.SiameseSpectralModel import SiameseSpectralModel
-from ms2deepscore.vector_operations import (cosine_similarity,
-                                            cosine_similarity_matrix)
+from ms2deepscore.vector_operations import cosine_similarity, cosine_similarity_matrix
 
 
 class MS2DeepScoreEvaluated(BaseSimilarity):
-    """Calculate MS2DeepScore similarity scores between a reference and a query.
-
+    """MS2DeepScore plus a predicted absolute-error field.
+    
     Using a trained model, binned spectrums will be converted into spectrum
     vectors using a deep neural network. The MS2DeepScore similarity is then
     the cosine similarity score between two spectrum vectors.
 
     Example code to calcualte MS2DeepScore similarities between query and reference
     spectrums:
+
+    # TODO: update code example to matchms 1.0
 
     .. code-block:: python
 
@@ -40,53 +48,52 @@ class MS2DeepScoreEvaluated(BaseSimilarity):
         scores = calculate_scores(references, queries, similarity_measure)
 
     """
-    # Set output data type, e.g. ("score", "float") or [("score", "float"), ("matches", "int")]
-    score_datatype = [("score", np.float32), ("predicted_absolute_error", np.float32)]
 
-    def __init__(self, model: SiameseSpectralModel,
-                 embedding_evaluator,
-                 score_evaluator,
-                 progress_bar: bool = True):
-        """
+    score_datatype = np.dtype(
+        [("score", np.float32), ("predicted_absolute_error", np.float32)]
+    )
+    score_fields = ("score", "predicted_absolute_error")
 
-        Parameters
-        ----------
-        model:
-            Expected input is a SiameseModel that has been trained on
-            the desired set of spectra.
-        embedding_evaluator:
-            Model trained on predicting the score quality (in form of MSE) based on an embedding.
-        progress_bar:
-            Set to True to monitor the embedding creating with a progress bar.
-            Default is False.
-        """
+    def __init__(
+        self,
+        model: SiameseSpectralModel,
+        embedding_evaluator,
+        score_evaluator,
+        progress_bar: bool = True,
+    ):
         self.model = model
         self.model.eval()
         self.embedding_evaluator = embedding_evaluator
-        self.embedding_evaluator .eval()
+        self.embedding_evaluator.eval()
         self.score_evaluator = score_evaluator
         self.output_vector_dim = self.model.model_settings.embedding_dim
         self.progress_bar = progress_bar
 
-    def get_embedding_array(self, spectrums, datatype="numpy", batch_size=1024):
+    def get_embedding_array(
+        self,
+        spectra,
+        datatype="numpy",
+        batch_size=1024,
+        progress_bar: bool | None = None,
+    ):
+        show_progress = self.progress_bar if progress_bar is None else progress_bar
         return self.model.compute_embedding_array(
-            spectrums,
+            spectra,
             datatype=datatype,
             batch_size=batch_size,
-            progress_bar=self.progress_bar,
+            progress_bar=show_progress,
         )
 
     def get_embedding_evaluations(self, embeddings):
-        """Compute the RMSE.
-        """
+        """Compute predicted embedding RMSE values."""
         predicted_mse = self.embedding_evaluator(embeddings)
         predicted_mse[predicted_mse < 0] = 0
-        return predicted_mse ** 0.5
+        return predicted_mse**0.5
 
     def get_score_evaluations(self, predicted_mse1, predicted_mse2):
         return compute_error_predictions(predicted_mse1, predicted_mse2, self.score_evaluator)
 
-    def pair(self, reference: Spectrum, query: Spectrum) -> float:
+    def pair(self, reference: Spectrum, query: Spectrum):
         """Calculate the MS2DeepScore similaritiy between a reference and a query spectrum.
 
         Parameters
@@ -101,42 +108,37 @@ class MS2DeepScoreEvaluated(BaseSimilarity):
         ms2ds_similarity
             MS2DeepScore similarity score.
         """
-        embedding_reference = self.get_embedding_array([reference], datatype="pytorch")
-        embedding_query = self.get_embedding_array([query], datatype="pytorch")
-
-        embedding_ref_mse = (
+        embeddings = self.get_embedding_array(
+            [reference, query], datatype="pytorch"
+        )
+        evaluations = (
             self.get_embedding_evaluations(
-                embedding_reference.reshape(-1, 1, self.output_vector_dim)
+                embeddings.reshape(-1, 1, self.output_vector_dim)
             )
             .detach()
+            .cpu()
             .numpy()
         )
-        embedding_query_mse = (
-            self.get_embedding_evaluations(
-                embedding_query.reshape(-1, 1, self.output_vector_dim)
-            )
-            .detach()
-            .numpy()
-        )
-
         score = cosine_similarity(
-            embedding_reference[0, :].detach().numpy(),
-            embedding_query[0, :].detach().numpy(),
+            embeddings[0, :].detach().cpu().numpy(),
+            embeddings[1, :].detach().cpu().numpy(),
         )
         score_predicted_ae = self.get_score_evaluations(
-            embedding_ref_mse,
-            embedding_query_mse,
+            evaluations[0:1], evaluations[1:2]
         )[0, 0]
-
         return np.asarray(
-            (float(score), float(score_predicted_ae)),
-            dtype=self.score_datatype,
+            (float(score), float(score_predicted_ae)), dtype=self.score_datatype
         )
 
-
-    def matrix(self, references: List[Spectrum], queries: List[Spectrum],
-               array_type: str = "numpy",
-               is_symmetric: bool = False) -> np.ndarray:
+    def _matrix_components(
+        self,
+        references: List[Spectrum],
+        queries: List[Spectrum],
+        *,
+        is_symmetric: bool,
+        progress_bar: bool,
+        requested_fields: tuple[str, ...],
+    ) -> dict[str, np.ndarray]:
         """Calculate the MS2DeepScore similarities between all references and queries.
 
         Parameters
@@ -145,34 +147,102 @@ class MS2DeepScoreEvaluated(BaseSimilarity):
             Reference spectrum.
         queries:
             Query spectrum.
-        array_type
-            Specify the output array type. Can be "numpy" or "sparse".
-            Currently, only "numpy" is supported and will return a numpy array.
-            Future versions will include "sparse" as option to return a COO-sparse array.
-        is_symmetric:
-            Set to True if references == queries to speed up calculation about 2x.
-            Uses the fact that in this case score[i, j] = score[j, i]. Default is False.
-
-        Returns
-        -------
-        ms2ds_similarity
-            Array of MS2DeepScore similarity scores.
+        progress_bar:
+            Set to True to monitor the embedding creating with a progress bar.
         """
-        embeddings_reference = self.get_embedding_array(references, datatype="pytorch")
+        embeddings_reference = self.get_embedding_array(
+            references, datatype="pytorch", progress_bar=progress_bar
+        )
         if is_symmetric:
-            assert np.all(references == queries), \
-                "Expected references to be equal to queries for is_symmetric=True"
             embeddings_query = embeddings_reference
         else:
-            embeddings_query = self.get_embedding_array(queries, datatype="pytorch")
+            embeddings_query = self.get_embedding_array(
+                queries, datatype="pytorch", progress_bar=progress_bar
+            )
 
-        embeddings_ref_mse = self.get_embedding_evaluations(embeddings_reference.reshape(-1, 1, self.output_vector_dim)).detach().numpy()
-        embeddings_query_mse = self.get_embedding_evaluations(embeddings_query.reshape(-1, 1, self.output_vector_dim)).detach().numpy()
+        result: dict[str, np.ndarray] = {}
 
-        ms2ds_similarity = cosine_similarity_matrix(embeddings_reference.detach().numpy(), embeddings_query.detach().numpy())
-        ms2ds_uncertainty = self.get_score_evaluations(embeddings_ref_mse, embeddings_query_mse)
-        similarities=np.empty((ms2ds_similarity.shape[0],
-                              ms2ds_similarity.shape[1]), dtype=self.score_datatype)
-        similarities["score"] = ms2ds_similarity
-        similarities["predicted_absolute_error"] = ms2ds_uncertainty
-        return similarities
+        if "score" in requested_fields:
+            result["score"] = cosine_similarity_matrix(
+                embeddings_reference.detach().cpu().numpy(),
+                embeddings_query.detach().cpu().numpy(),
+            ).astype(np.float32, copy=False)
+
+        if "predicted_absolute_error" in requested_fields:
+            embeddings_ref_mse = (
+                self.get_embedding_evaluations(
+                    embeddings_reference.reshape(-1, 1, self.output_vector_dim)
+                )
+                .detach()
+                .cpu()
+                .numpy()
+            )
+            if is_symmetric:
+                embeddings_query_mse = embeddings_ref_mse
+            else:
+                embeddings_query_mse = (
+                    self.get_embedding_evaluations(
+                        embeddings_query.reshape(-1, 1, self.output_vector_dim)
+                    )
+                    .detach()
+                    .cpu()
+                    .numpy()
+                )
+            result["predicted_absolute_error"] = self.get_score_evaluations(
+                embeddings_ref_mse, embeddings_query_mse
+            ).astype(np.float32, copy=False)
+
+        return result
+
+    if MATCHMS_V1_API:
+
+        def matrix(
+            self,
+            spectra_1: List[Spectrum],
+            spectra_2: List[Spectrum] | None = None,
+            score_fields=None,
+            progress_bar: bool = True,
+        ):
+            requested_fields = normalize_score_fields(score_fields, self.score_fields)
+            is_symmetric = spectra_2 is None or spectra_2 is spectra_1
+            queries = spectra_1 if spectra_2 is None else spectra_2
+            score_arrays = self._matrix_components(
+                spectra_1,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+                requested_fields=requested_fields,
+            )
+            return as_matchms_scores(score_arrays)
+
+    else:
+
+        def matrix(
+            self,
+            references: List[Spectrum],
+            queries: List[Spectrum],
+            array_type: str = "numpy",
+            is_symmetric: bool = False,
+            progress_bar: bool = True,
+        ) -> np.ndarray:
+            if array_type != "numpy":
+                raise NotImplementedError(
+                    "MS2DeepScoreEvaluated currently supports only array_type='numpy'."
+                )
+            if is_symmetric:
+                assert_legacy_symmetric_inputs(references, queries)
+            components = self._matrix_components(
+                references,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+                requested_fields=self.score_fields,
+            )
+            similarities = np.empty(
+                components["score"].shape, dtype=self.score_datatype
+            )
+            similarities["score"] = components["score"]
+            similarities["predicted_absolute_error"] = components[
+                "predicted_absolute_error"
+            ]
+            return similarities

--- a/ms2deepscore/MS2DeepScoreONNX.py
+++ b/ms2deepscore/MS2DeepScoreONNX.py
@@ -1,7 +1,15 @@
 from typing import List
+
 import numpy as np
 from matchms import Spectrum
-from matchms.similarity.BaseSimilarity import BaseSimilarity
+
+from ms2deepscore.matchms_compat import (
+    MATCHMS_V1_API,
+    BaseSimilarity,
+    as_matchms_scores,
+    normalize_score_fields,
+    assert_legacy_symmetric_inputs,
+)
 from ms2deepscore.models import SiameseSpectralModelONNX
 from .vector_operations import cosine_similarity, cosine_similarity_matrix
 
@@ -37,6 +45,8 @@ class MS2DeepScoreONNX(BaseSimilarity):
 
     """
 
+    score_fields = ("score",)
+
     def __init__(self, model: SiameseSpectralModelONNX, progress_bar: bool = True):
         """
 
@@ -51,8 +61,9 @@ class MS2DeepScoreONNX(BaseSimilarity):
         self.output_vector_dim = self.model.model_settings.embedding_dim
         self.progress_bar = progress_bar
 
-    def get_embedding_array(self, spectra) -> np.ndarray:
-        return self.model.compute_embedding_array(spectra, progress_bar=self.progress_bar)
+    def get_embedding_array(self, spectra, progress_bar: bool | None = None) -> np.ndarray:
+        show_progress = self.progress_bar if progress_bar is None else progress_bar
+        return self.model.compute_embedding_array(spectra, progress_bar=show_progress)
 
     def pair(self, reference: Spectrum, query: Spectrum) -> float:
         """Calculate the MS2DeepScore similaritiy between a reference and a query spectrum.
@@ -69,18 +80,16 @@ class MS2DeepScoreONNX(BaseSimilarity):
         ms2ds_similarity
             MS2DeepScore similarity score.
         """
-        embedding_reference = self.get_embedding_array([reference])
-        embedding_query = self.get_embedding_array([query])
+        embeddings = self.get_embedding_array([reference, query])
+        return cosine_similarity(embeddings[0, :], embeddings[1, :])
 
-        return cosine_similarity(embedding_reference[0, :], embedding_query[0, :])
-
-    def matrix(
+    def _matrix_numpy(
         self,
         references: List[Spectrum],
         queries: List[Spectrum],
-        array_type: str = "numpy",
-        is_symmetric: bool = False,
-        progress_bar: bool = True,
+        *,
+        is_symmetric: bool,
+        progress_bar: bool,
     ) -> np.ndarray:
         """Calculate the MS2DeepScore similarities between all references and queries.
 
@@ -99,19 +108,55 @@ class MS2DeepScoreONNX(BaseSimilarity):
             Uses the fact that in this case score[i, j] = score[j, i]. Default is False.
         progress_bar:
             When True a progress bar is shown. Default is True.
-
-        Returns
-        -------
-        ms2ds_similarity
-            Array of MS2DeepScore similarity scores.
         """
-        embeddings_reference = self.get_embedding_array(references)
+        embeddings_reference = self.get_embedding_array(
+            references, progress_bar=progress_bar
+        )
         if is_symmetric:
-            assert np.all(references == queries), "Expected references to be equal to queries for is_symmetric=True"
             embeddings_query = embeddings_reference
         else:
-            embeddings_query = self.get_embedding_array(queries)
+            embeddings_query = self.get_embedding_array(
+                queries, progress_bar=progress_bar
+            )
+        return cosine_similarity_matrix(embeddings_reference, embeddings_query)
 
-        ms2ds_similarity = cosine_similarity_matrix(embeddings_reference, embeddings_query)
+    if MATCHMS_V1_API:
 
-        return ms2ds_similarity
+        def matrix(
+            self,
+            spectra_1: List[Spectrum],
+            spectra_2: List[Spectrum] | None = None,
+            score_fields=None,
+            progress_bar: bool = True,
+        ):
+            normalize_score_fields(score_fields, self.score_fields)
+            is_symmetric = spectra_2 is None or spectra_2 is spectra_1
+            queries = spectra_1 if spectra_2 is None else spectra_2
+            score_matrix = self._matrix_numpy(
+                spectra_1,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+            )
+            return as_matchms_scores({"score": score_matrix})
+
+    else:
+
+        def matrix(
+            self,
+            references: List[Spectrum],
+            queries: List[Spectrum],
+            array_type: str = "numpy",
+            is_symmetric: bool = False,
+            progress_bar: bool = True,
+        ) -> np.ndarray:
+            if array_type != "numpy":
+                raise NotImplementedError("MS2DeepScoreONNX currently supports only array_type='numpy'.")
+            if is_symmetric:
+                assert_legacy_symmetric_inputs(references, queries)
+            return self._matrix_numpy(
+                references,
+                queries,
+                is_symmetric=is_symmetric,
+                progress_bar=progress_bar,
+            )

--- a/ms2deepscore/MS2DeepScoreONNX.py
+++ b/ms2deepscore/MS2DeepScoreONNX.py
@@ -5,11 +5,14 @@ from matchms import Spectrum
 
 from ms2deepscore.matchms_compat import (
     MATCHMS_V1_API,
-    BaseSimilarity,
     as_matchms_scores,
     normalize_score_fields,
     assert_legacy_symmetric_inputs,
 )
+if MATCHMS_V1_API:
+    from matchms.similarity.base_similarity import BaseSimilarity
+else:
+    from matchms.similarity.BaseSimilarity import BaseSimilarity
 from ms2deepscore.models import SiameseSpectralModelONNX
 from .vector_operations import cosine_similarity, cosine_similarity_matrix
 

--- a/ms2deepscore/MetadataFeatureGenerator.py
+++ b/ms2deepscore/MetadataFeatureGenerator.py
@@ -3,7 +3,7 @@ from importlib import import_module
 from typing import List, Optional, Tuple, Union
 from torch import zeros, tensor
 from matchms import Metadata
-from matchms.Spectrum import Spectrum
+from matchms import Spectrum
 from tqdm import tqdm
 
 
@@ -118,7 +118,7 @@ class StandardScaler(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if self.metadata_field is None:
+        if feature is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if not isinstance(feature, (int, float)):
             raise TypeError(f"Expected float or int, got {feature}, for {self.metadata_field}")
@@ -153,7 +153,7 @@ class OneHotEncoder(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if self.metadata_field is None:
+        if feature is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature == self.entries_becoming_one:
             return 1
@@ -196,7 +196,7 @@ class CategoricalToBinary(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if self.metadata_field is None:
+        if feature is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature in self.entries_becoming_one:
             return 1

--- a/ms2deepscore/MetadataFeatureGenerator.py
+++ b/ms2deepscore/MetadataFeatureGenerator.py
@@ -118,7 +118,7 @@ class StandardScaler(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if feature is None:
+        if self.metadata_field is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if not isinstance(feature, (int, float)):
             raise TypeError(f"Expected float or int, got {feature}, for {self.metadata_field}")
@@ -153,7 +153,7 @@ class OneHotEncoder(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if feature is None:
+        if self.metadata_field is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature == self.entries_becoming_one:
             return 1
@@ -196,7 +196,7 @@ class CategoricalToBinary(MetadataFeatureGenerator):
 
     def generate_features(self, metadata: Metadata):
         feature = metadata.get(self.metadata_field, None)
-        if feature is None:
+        if self.metadata_field is None:
             raise ValueError(f"Metadata entry for {self.metadata_field} is missing.")
         if feature in self.entries_becoming_one:
             return 1

--- a/ms2deepscore/matchms_compat.py
+++ b/ms2deepscore/matchms_compat.py
@@ -1,24 +1,15 @@
 """Compatibility helpers for matchms pre-1.0 and >=1.0 APIs.
-
-The matchms 1.0 refactor renamed the BaseSimilarity module and changed the
-``matrix`` contract from returning a NumPy array to returning ``matchms.Scores``.
-Keep all version-dependent imports/return wrapping in one place so that the
-actual similarity implementations stay readable.
 """
 
 from __future__ import annotations
 from typing import Iterable, Tuple
+import matchms.__version__ as matchms_version
 
-try:  # matchms >= 1.0
+MATCHMS_V1_API = matchms_version.startswith("1.")
+if MATCHMS_V1_API:
     from matchms import Scores
-    from matchms.similarity.base_similarity import BaseSimilarity
-
-    MATCHMS_V1_API = True
-except ImportError:  # matchms <= 0.33.x
-    from matchms.similarity.BaseSimilarity import BaseSimilarity
-
-    Scores = None  # type: ignore[assignment]
-    MATCHMS_V1_API = False
+else:
+    Scores = None
 
 
 def normalize_score_fields(

--- a/ms2deepscore/matchms_compat.py
+++ b/ms2deepscore/matchms_compat.py
@@ -1,0 +1,63 @@
+"""Compatibility helpers for matchms pre-1.0 and >=1.0 APIs.
+
+The matchms 1.0 refactor renamed the BaseSimilarity module and changed the
+``matrix`` contract from returning a NumPy array to returning ``matchms.Scores``.
+Keep all version-dependent imports/return wrapping in one place so that the
+actual similarity implementations stay readable.
+"""
+
+from __future__ import annotations
+from typing import Iterable, Tuple
+
+try:  # matchms >= 1.0
+    from matchms import Scores
+    from matchms.similarity.base_similarity import BaseSimilarity
+
+    MATCHMS_V1_API = True
+except ImportError:  # matchms <= 0.33.x
+    from matchms.similarity.BaseSimilarity import BaseSimilarity
+
+    Scores = None  # type: ignore[assignment]
+    MATCHMS_V1_API = False
+
+
+def normalize_score_fields(
+    score_fields: Iterable[str] | str | None,
+    available_fields: Tuple[str, ...],
+) -> Tuple[str, ...]:
+    """Validate/normalize requested score fields for the matchms >=1.0 API."""
+    if score_fields is None:
+        return available_fields
+    if isinstance(score_fields, str):
+        fields = (score_fields,)
+    else:
+        fields = tuple(score_fields)
+
+    unknown = tuple(field for field in fields if field not in available_fields)
+    if unknown:
+        raise ValueError(
+            f"Unknown score field(s): {unknown}. Available fields are {available_fields}."
+        )
+    if len(fields) == 0:
+        raise ValueError("score_fields must contain at least one field.")
+    return fields
+
+
+def as_matchms_scores(score_arrays: dict[str, object]):
+    """Wrap score matrices in the matchms >=1.0 Scores container."""
+    if not MATCHMS_V1_API or Scores is None:
+        raise RuntimeError("matchms.Scores wrapping is only available with the matchms >=1.0 API.")
+    return Scores(score_arrays)
+
+
+def assert_legacy_symmetric_inputs(references, queries) -> None:
+    """Preserve the <=0.33 ``is_symmetric=True`` validation behavior."""
+    if references is queries:
+        return
+    try:
+        equal = len(references) == len(queries) and all(
+            reference == query for reference, query in zip(references, queries)
+        )
+    except Exception:
+        equal = False
+    assert equal, "Expected references to be equal to queries for is_symmetric=True"

--- a/ms2deepscore/models/EmbeddingEvaluatorModel.py
+++ b/ms2deepscore/models/EmbeddingEvaluatorModel.py
@@ -6,7 +6,7 @@ from torch import float32, cuda, tensor, cat
 from torch import device as torch_device
 from torch import no_grad
 import torch.nn.functional as F
-from matchms.Spectrum import Spectrum
+from matchms import Spectrum
 from torch import nn, optim
 from ms2deepscore.__version__ import __version__
 from ms2deepscore.models.helper_functions import initialize_device

--- a/notebooks/model_benchmarking/EmbeddingEvaluator_benchmarking.ipynb
+++ b/notebooks/model_benchmarking/EmbeddingEvaluator_benchmarking.ipynb
@@ -5312,7 +5312,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matchms.Spectrum import Spectrum\n",
+    "from matchms import Spectrum\n",
     "import numpy as np\n",
     "\n",
     "def plot_predicted_mse_random_noise(nr_of_peaks=10, intensity_normalization= 1, nr_of_spectra = 1000, ionmode=\"positive\", precursor_mz=None, mz_spread=990, min_mz=10):\n",

--- a/notebooks/ms2deepscore_2_preprint/EmbeddingEvaluator.ipynb
+++ b/notebooks/ms2deepscore_2_preprint/EmbeddingEvaluator.ipynb
@@ -1843,7 +1843,7 @@
     }
    ],
    "source": [
-    "from matchms.Spectrum import Spectrum\n",
+    "from matchms import Spectrum\n",
     "import numpy as np\n",
     "\n",
     "predict_mse(Spectrum(mz=np.array([5.]), intensities=np.array([1.0,]), metadata={\"precursor_mz\": 300, \"ionmode\": \"positive\",}))\n",

--- a/tests/test_ms2deepscore.py
+++ b/tests/test_ms2deepscore.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from ms2deepscore import MS2DeepScore
+from ms2deepscore.matchms_compat import MATCHMS_V1_API
 from ms2deepscore.models import load_model
 from tests.create_test_spectra import pesticides_test_spectra
 
@@ -47,6 +48,8 @@ def test_MS2DeepScore_score_matrix():
     """Test score calculation using *.matrix* method."""
     spectrums, _, similarity_measure = get_test_ms2deepscore_instance()
     scores = similarity_measure.matrix(spectrums[:4], spectrums[:3])
+    if MATCHMS_V1_API:
+        scores = scores.to_array("score")
 
     expected_scores = np.array([
         [1.        , 0.99036639, 0.99084978],
@@ -60,7 +63,10 @@ def test_MS2DeepScore_score_matrix():
 def test_MS2DeepScore_score_matrix_symmetric():
     """Test score calculation using *.matrix* method."""
     spectrums, _, similarity_measure = get_test_ms2deepscore_instance()
-    scores = similarity_measure.matrix(spectrums[:4], spectrums[:4], is_symmetric=True)
+    if MATCHMS_V1_API:
+        scores = similarity_measure.matrix(spectrums[:4]).to_array("score")
+    else:
+        scores = similarity_measure.matrix(spectrums[:4], spectrums[:4], is_symmetric=True)
     expected_scores = np.array([
         [1.        , 0.99036639, 0.99084978, 0.98811793],
         [0.99036639, 1.        , 0.99399306, 0.96436209],
@@ -71,10 +77,11 @@ def test_MS2DeepScore_score_matrix_symmetric():
 
 def test_MS2DeepScore_score_matrix_symmetric_wrong_use():
     """Test if *.matrix* method gives correct exception."""
-    spectrums, _, similarity_measure = get_test_ms2deepscore_instance()
-    expected_msg = "Expected references to be equal to queries for is_symmetric=True"
-    with pytest.raises(AssertionError) as msg:
-        _ = similarity_measure.matrix(spectrums[:4],
-                                      [spectrums[i] for i in [1,2,3,0]],
-                                      is_symmetric=True)
-    assert expected_msg in str(msg), "Expected different exception message"
+    if not MATCHMS_V1_API:  # test makes no sense for matchms >= 1.0
+        spectrums, _, similarity_measure = get_test_ms2deepscore_instance()
+        expected_msg = "Expected references to be equal to queries for is_symmetric=True"
+        with pytest.raises(AssertionError) as msg:
+            _ = similarity_measure.matrix(spectrums[:4],
+                                        [spectrums[i] for i in [1,2,3,0]],
+                                        is_symmetric=True)
+        assert expected_msg in str(msg), "Expected different exception message"

--- a/tests/test_ms2deepscore_evaluated.py
+++ b/tests/test_ms2deepscore_evaluated.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import numpy as np
 from ms2deepscore import MS2DeepScoreEvaluated
+from ms2deepscore.matchms_compat import MATCHMS_V1_API
 from ms2deepscore.SettingsMS2Deepscore import SettingsEmbeddingEvaluator
 from ms2deepscore.models import load_model, LinearModel, EmbeddingEvaluationModel
 from tests.create_test_spectra import pesticides_test_spectra
@@ -48,6 +49,8 @@ def test_MS2DeepScore_score_matrix():
     """Test score calculation using *.matrix* method."""
     spectrums, similarity_measure = get_test_ms2deepscore_evaluated_instance()
     scores = similarity_measure.matrix(spectrums[:3], spectrums[:4])
+    if MATCHMS_V1_API:
+        scores = scores.to_array("score")
 
     expected_scores = np.array([
         [1.        , 0.9903664 , 0.9908498 , 0.98811793],

--- a/tests/test_ms2deepscore_onnx.py
+++ b/tests/test_ms2deepscore_onnx.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from ms2deepscore import MS2DeepScoreONNX
+from ms2deepscore.matchms_compat import MATCHMS_V1_API
 from ms2deepscore.models import SiameseSpectralModelONNX
 from tests.create_test_spectra import pesticides_test_spectra
 
@@ -43,6 +44,8 @@ def test_MS2DeepScoreONNX_score_matrix():
     """Test score calculation using *.matrix* method."""
     spectrums, model, similarity_measure = get_test_ms2deepscore_onnx_instance()
     scores = similarity_measure.matrix(spectrums[:4], spectrums[:3])
+    if MATCHMS_V1_API:
+        scores = scores.to_array("score")
 
     expected_scores = np.array(
         [
@@ -61,7 +64,10 @@ def test_MS2DeepScoreONNX_score_matrix():
 def test_MS2DeepScoreONNX_score_matrix_symmetric():
     """Test score calculation using *.matrix* method with is_symmetric=True."""
     spectrums, model, similarity_measure = get_test_ms2deepscore_onnx_instance()
-    scores = similarity_measure.matrix(spectrums[:4], spectrums[:4], is_symmetric=True)
+    if MATCHMS_V1_API:
+        scores = similarity_measure.matrix(spectrums[:4]).to_array("score")
+    else:
+        scores = similarity_measure.matrix(spectrums[:4], spectrums[:4], is_symmetric=True)
 
     expected_scores = np.array(
         [
@@ -77,10 +83,11 @@ def test_MS2DeepScoreONNX_score_matrix_symmetric():
 
 def test_MS2DeepScoreONNX_score_matrix_symmetric_wrong_use():
     """Test if *.matrix* method gives correct exception when references != queries."""
-    spectrums, _, similarity_measure = get_test_ms2deepscore_onnx_instance()
-    expected_msg = "Expected references to be equal to queries for is_symmetric=True"
+    if not MATCHMS_V1_API:  # test makes no sense for matchms >= 1.0
+        spectrums, _, similarity_measure = get_test_ms2deepscore_onnx_instance()
+        expected_msg = "Expected references to be equal to queries for is_symmetric=True"
 
-    with pytest.raises(AssertionError) as msg:
-        _ = similarity_measure.matrix(spectrums[:4], [spectrums[i] for i in [1, 2, 3, 0]], is_symmetric=True)
+        with pytest.raises(AssertionError) as msg:
+            _ = similarity_measure.matrix(spectrums[:4], [spectrums[i] for i in [1, 2, 3, 0]], is_symmetric=True)
 
-    assert expected_msg in str(msg.value), "Expected different exception message"
+        assert expected_msg in str(msg.value), "Expected different exception message"

--- a/tests/test_validation_loss_calculator.py
+++ b/tests/test_validation_loss_calculator.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from matchms.Spectrum import Spectrum
+from matchms import Spectrum
 
 from ms2deepscore import MS2DeepScore
 from ms2deepscore.SettingsMS2Deepscore import SettingsMS2Deepscore


### PR DESCRIPTION
This is to anticipate larger changes in matchms, see https://github.com/matchms/matchms/pull/909

- handles different file/module names between matchms >= 1.0 and <1.0
- handles new `Scores` class and computation style in matchms >= 1.0